### PR TITLE
chore: limit Node.js version updated by Dependabot to v20.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
     target-branch: 'main'
     ignore:
       - dependency-name: 'node'
-        versions: ['~>23.0']
+        versions: ['>=21.0']
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:


### PR DESCRIPTION
### Summary

To ensure the stability and security of my project by relying on the LTS version, I am modifying the Dependabot configuration to restrict Node.js updates to the LTS version v20.x.

### Changes

Changed the `ignore` value in `dependabot.yml`. This change ensures that Dependabot ignores Node.js versions v21.0 and above.

### Testing

- [x] Dependabot is configured to restrict Node.js version updates to v20.x

The following steps were taken to confirm that Dependabot creates a pull request to update Node.js to v20.0.16:

 1. Use [GitHub Importer](https://docs.github.com/en/migrations/importing-source-code/using-github-importer/importing-a-repository-with-github-importer) to create a clone of the repository.
 2. Merge the `chore/138-limit-node.js-version` branch of the cloned repository into the `main` branch.
 3. Confirm that Dependabot creates a pull request to update Node.js to v20.16.0.

As shown in the image below, the pull request was successfully created.


<img width="1256" alt="スクリーンショット 2024-08-04 17 05 03" src="https://github.com/user-attachments/assets/6c90a482-903c-4bbf-bbcc-0a63c296451d">

### Related Issues (Optional)

None

### Notes (Optional)

None
