### PR TITLE
chore: fix build errors in Next.js

### DIFF
--- a/src/app/(auth)/login/_components/login-form/use-login-form.tsx
+++ b/src/app/(auth)/login/_components/login-form/use-login-form.tsx
@@ -38,7 +38,6 @@ export function useLoginForm({ csrfToken }: UseLoginFormParams) {
         reset()
         const fromUrl = searchParams.get('from_url')
         let targetUrl = `${origin}/tasks`
-        // @ts-expect-error
         if (fromUrl && URL.canParse(fromUrl)) {
           const fromOrigin = new URL(fromUrl).origin
           if (fromOrigin === origin) {
@@ -48,7 +47,7 @@ export function useLoginForm({ csrfToken }: UseLoginFormParams) {
         location.assign(targetUrl)
       }
     },
-    [openErrorSnackbar, reset, searchParams, csrfToken]
+    [openErrorSnackbar, reset, searchParams, csrfToken],
   )
 
   return {

--- a/src/app/(auth)/password/change/page.tsx
+++ b/src/app/(auth)/password/change/page.tsx
@@ -16,7 +16,6 @@ export default function ChangePassword() {
       <AuthHeading className="mb-8">パスワード変更</AuthHeading>
       <div className="mx-2">
         <Suspense fallback={<LoadingCurrentUserChangePasswordForm />}>
-          {/* @ts-expect-error */}
           <CurrentUserChangePasswordForm />
         </Suspense>
       </div>

--- a/src/app/(main)/@modal/(.)users/[id]/page.tsx
+++ b/src/app/(main)/@modal/(.)users/[id]/page.tsx
@@ -10,8 +10,5 @@ type Props = {
 }
 
 export default function User({ params: { id } }: Props) {
-  return (
-    // @ts-expect-error
-    <UserPage id={id} />
-  )
+  return <UserPage id={id} />
 }

--- a/src/app/(main)/_components/main-header/index.tsx
+++ b/src/app/(main)/_components/main-header/index.tsx
@@ -26,7 +26,6 @@ export function MainHeader() {
             <NavLinks className="space-x-3.5 max-md:hidden" />
           </div>
           <Suspense fallback={<LoadingAccountAvatarLink />}>
-            {/* @ts-expect-error */}
             <CurrentUserAvatarLink />
           </Suspense>
         </div>

--- a/src/app/(main)/users/[id]/page.tsx
+++ b/src/app/(main)/users/[id]/page.tsx
@@ -10,7 +10,6 @@ type Props = {
 export default function User({ params: { id } }: Props) {
   return (
     <Suspense fallback={<LoadingUserPage />}>
-      {/* @ts-expect-error */}
       <UserPage id={id} />
     </Suspense>
   )

--- a/src/app/_components/snackbars/snackbar/index.tsx
+++ b/src/app/_components/snackbars/snackbar/index.tsx
@@ -54,7 +54,6 @@ export function Snackbar({
           ? 'animate-slide-in-top md:animate-slide-in-bottom'
           : 'animate-slide-out-top md:animate-slide-out-bottom'
       }`}
-      // @ts-expect-error
       popover="manual"
       onAnimationEnd={handleAnimationEnd}
     >

--- a/src/app/_components/snackbars/snackbar/use-snackbar.tsx
+++ b/src/app/_components/snackbars/snackbar/use-snackbar.tsx
@@ -23,12 +23,11 @@ export function useSnackbar({ id, isOpen, actionButton }: Params) {
         }
       }
     },
-    [closeSnackbar, id]
+    [closeSnackbar, id],
   )
 
   const handleAnimationEnd = useCallback(() => {
     if (!isOpen) {
-      // @ts-expect-error
       ref.current?.hidePopover()
       cleanupSnackbar(id)
     }
@@ -42,7 +41,6 @@ export function useSnackbar({ id, isOpen, actionButton }: Params) {
 
   useEffect(() => {
     if (isOpen) {
-      // @ts-expect-error
       ref.current?.showPopover()
 
       const timer = setTimeout(() => {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,25 +1,26 @@
 import { Snackbars } from './_components/snackbars'
 import './globals.css'
-import type { Metadata } from 'next'
+import type { Metadata, Viewport } from 'next'
 
 export const metadata: Metadata = {
   title: {
     default: 'TASCON',
     template: '%s | TASCON',
   },
-  viewport: {
-    width: 'device-width',
-    viewportFit: 'cover',
-    initialScale: 1,
-    maximumScale: 1,
-  },
   description: 'タスク管理とテンプレートの共有',
   manifest: '/manifest.json',
-  themeColor: '#F5F7FC',
   icons: {
     icon: '/icons/icon-192x192.png',
     apple: '/icons/apple-touch-icon.png',
   },
+}
+
+export const viewport: Viewport = {
+  themeColor: '#F5F7FC',
+  width: 'device-width',
+  viewportFit: 'cover',
+  initialScale: 1,
+  maximumScale: 1,
 }
 
 type Props = {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from 'react'
 import { HomeHeader } from './_components/home-header'
 import { HomeQueryParamSnackbar } from './_components/home-query-param-snackbar'
 import { SignUpLink } from './_components/sign-up-link'
@@ -11,7 +12,9 @@ export default function Home() {
         <BottomBar className="lg:hidden">
           <SignUpLink className="h-9 w-64" />
         </BottomBar>
-        <HomeQueryParamSnackbar />
+        <Suspense>
+          <HomeQueryParamSnackbar />
+        </Suspense>
       </main>
     </>
   )

--- a/src/components/pages/account-page/index.tsx
+++ b/src/components/pages/account-page/index.tsx
@@ -26,7 +26,6 @@ export function AccountPage() {
   return (
     <div className="flex flex-col gap-y-10">
       <Suspense fallback={<LoadingCurrentUserInfo />}>
-        {/* @ts-expect-error */}
         <CurrentUserInfo />
       </Suspense>
       <HorizontalRule />


### PR DESCRIPTION
### Summary

To enable functionality verification, we will make the necessary changes to fix the errors encountered when running `yarn build` in the terminal.

### Changes

- Remove unnecessary `@ts-expect-error`
- Change `metadata`'s `viewport` to a [viewport object](https://is.gd/M2ezt6)
- wrap the component that uses `useSearchParams` in the static rendering page with `Suspense`.
This change prevents the entire static rendering page from becoming client-side rendering.

### Testing

- [x] `yarn build` completes successfully
Confirmed that the build completes successfully by running `yarn build` in the terminal.

### Related Issues (Optional)

None

### Notes (Optional)

- [Entire page deopted into client-side rendering](https://nextjs.org/docs/messages/deopted-into-client-rendering)
- [Missing Suspense boundary with useSearchParams](https://nextjs.org/docs/messages/missing-suspense-with-csr-bailout)