### PR TITLE
chore: remove develop from Lefthook protect-branch

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -25,8 +25,8 @@ pre-commit:
       run: yarn knip --include files --exports
       fail_text: 'Read the report above.'
     protect-branch:
-      run: git branch --show-current | tee /dev/tty | grep -Eqvx 'main|develop'
-      fail_text: "ERROR: Do NOT commit directly to 'main' or 'develop' branch."
+      run: git branch --show-current | tee /dev/tty | grep -Eqvx 'main'
+      fail_text: "ERROR: Do NOT commit directly to 'main' branch."
 pre-push:
   commands:
     knip-dependencies:


### PR DESCRIPTION
### Summary

Due to the change in branch strategy from Git Flow to GitHub Flow, the `develop` branch has been deleted.
However, there are still references to the `develop` branch in Lefthook `protect-branch`.
To improve code quality, we will remove the unnecessary references to the `develop` branch from Lefthook `protect-branch`.

### Changes

- Removed `develop` from Lefthook `protect-branch`.

### Testing

- [x] References to the `develop` branch in Lefthook `protect-branch` have been removed.

- [x] Committing to the `main` branch causes an error with Lefthook.
Confirmed that committing to the `main` branch is not allowed by running `yarn lefthook run pre-commit` in the terminal.

<details>
  <summary>Execution Result</summary>

```shell
node ➜ ~/tascon-frontend (main) $ yarn lefthook run pre-commit
╭───────────────────────────────────────╮
│ 🥊 lefthook v1.7.11  hook: pre-commit │
╰───────────────────────────────────────╯
sync hooks: ✔️ (pre-commit, pre-push)
│  markdownlint (skip) no files for inspection
┃  protect-branch ❯ 

main

│  eslint (skip) no files for inspection
│  check-logger-trace (skip) no files for inspection
┃  prettier ❯ 

lefthook.yml 25ms (unchanged)

┃  knip-files-exports ❯ 

✂️  Excellent, Knip found no issues.

                                      
  ────────────────────────────────────
summary: (done in 1.85 seconds)       
✔️  prettier
✔️  knip-files-exports
🥊  protect-branch: ERROR: Do NOT commit directly to 'main' branch.
```

</details>

- [x] Able to commit without errors on the `develop` branch.
Confirmed that committing to the `develop` branch is allowed by running `yarn lefthook run pre-commit` in the terminal.

<details>
  <summary>Execution Result</summary>

```shell
node ➜ ~/tascon-frontend (develop) $ yarn lefthook run pre-commit
╭───────────────────────────────────────╮
│ 🥊 lefthook v1.7.11  hook: pre-commit │
╰───────────────────────────────────────╯
│  eslint (skip) no files for inspection
│  markdownlint (skip) no files for inspection
│  check-logger-trace (skip) no files for inspection
┃  protect-branch ❯ 

develop

┃  prettier ❯ 

lefthook.yml 25ms (unchanged)

┃  knip-files-exports ❯ 

✂️  Excellent, Knip found no issues.

                                      
  ────────────────────────────────────
summary: (done in 1.88 seconds)       
✔️  protect-branch
✔️  prettier
✔️  knip-files-exports
```

</details>

### Related Issues (Optional)

None

### Notes (Optional)

None
