### PR TITLE
chore: remove knip from scripts in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "start": "next start",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx .",
     "lint-fix": "eslint --ext .js,.jsx,.ts,.tsx --fix .",
-    "format": "prettier --write --ignore-unknown .",
-    "knip": "knip"
+    "format": "prettier --write --ignore-unknown ."
   },
   "dependencies": {
     "@heroicons/react": "^2.1.5",


### PR DESCRIPTION
### Summary

You can run `yarn knip` without `"knip": "knip"` in the `scripts` section of `package.json`. Therefore, this statement is not necessary. To improve the quality of the code, remove this unnecessary description.

### Changes

- Remove `"knip: "knip"` from the `scripts` section in `package.json`.

### Testing

- [x] The entry related to Knip is removed from the `scripts` section of the `package.json` file.
- [x] `yarn knip` functions correctly.
Confirmed that running `yarn knip` in the terminal before and after removing `"knip: "knip"` produces the same result.

<details>
  <summary>Execution Result</summary>

Before removal

```shell
node ➜ ~/tascon-frontend (chore/154-remove-knip-from-scripts) $ yarn knip
Configuration issues (11)
Unused item in ignoreDependencies: eslint
Unused item in ignoreDependencies: markdownlint-cli2
Unused item in ignoreDependencies: postcss
Unused item in ignoreDependencies: prettier
Unused item in ignoreDependencies: pino-pretty
Unused item in ignoreBinaries: eslint
Unused item in ignoreBinaries: knip
Unused item in ignoreBinaries: markdownlint-cli2
Unused item in ignoreBinaries: next
Unused item in ignoreBinaries: prettier
Unused item in ignoreBinaries: pino-pretty
✂️  Excellent, Knip found no issues.
```

After removal

```shell
node ➜ ~/tascon-frontend (chore/154-remove-knip-from-scripts) $ yarn knip
Configuration issues (11)
Unused item in ignoreDependencies: eslint
Unused item in ignoreDependencies: markdownlint-cli2
Unused item in ignoreDependencies: postcss
Unused item in ignoreDependencies: prettier
Unused item in ignoreDependencies: pino-pretty
Unused item in ignoreBinaries: eslint
Unused item in ignoreBinaries: knip
Unused item in ignoreBinaries: markdownlint-cli2
Unused item in ignoreBinaries: next
Unused item in ignoreBinaries: prettier
Unused item in ignoreBinaries: pino-pretty
✂️  Excellent, Knip found no issues.
```

</details>

### Related Issues (Optional)

None

### Notes (Optional)

None
