### PR TITLE
refactor: remove unnecessary entries from Knip configuration file

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -1,21 +1,5 @@
 {
   "$schema": "https://unpkg.com/knip@5/schema.json",
   "ignore": [".pnp.*"],
-  "ignoreBinaries": [
-    "eslint",
-    "knip",
-    "markdownlint-cli2",
-    "next",
-    "prettier",
-    "pino-pretty"
-  ],
-  "ignoreDependencies": [
-    "@evilmartians/lefthook",
-    "eslint",
-    "markdownlint-cli2",
-    "postcss",
-    "prettier",
-    "client-only",
-    "pino-pretty"
-  ]
+  "ignoreDependencies": ["@evilmartians/lefthook", "client-only"]
 }


### PR DESCRIPTION
### Summary

<!-- Briefly describe the purpose of the pull request and the changes it introduces -->
To complete Task #156, remove unnecessary descriptions from the Knip configuration file.

### Changes

<!-- Explain the specific changes or additions made -->

- Removed items that were outputted when running `yarn knip` from the Knip configuration file.

```shell
$ yarn knip
Configuration issues (11)
Unused item in ignoreDependencies: eslint
Unused item in ignoreDependencies: markdownlint-cli2
Unused item in ignoreDependencies: postcss
Unused item in ignoreDependencies: prettier
Unused item in ignoreDependencies: pino-pretty
Unused item in ignoreBinaries: eslint
Unused item in ignoreBinaries: knip
Unused item in ignoreBinaries: markdownlint-cli2
Unused item in ignoreBinaries: next
Unused item in ignoreBinaries: prettier
Unused item in ignoreBinaries: pino-pretty
```

### Testing

<!-- Describe how the changes were tested to ensure they work as expected -->
- [x] Only `✂️  Excellent, Knip found no issues.` should be displayed when running `yarn knip`.
Verified that only `✂️  Excellent, Knip found no issues.` is outputted when running `yarn knip` in the terminal.

```shell
node ➜ ~/tascon-frontend (refactor/156-clean-knip-config) $ yarn knip
✂️  Excellent, Knip found no issues.
```

### Related Issues (Optional)

None

### Notes (Optional)

None
