### PR TITLE
chore: fix Markuplint errors

### DIFF
--- a/.markuplintrc
+++ b/.markuplintrc
@@ -7,5 +7,13 @@
   },
   "extends": [
     "markuplint:recommended-react"
+  ],
+  "nodeRules": [
+    {
+      "selector": "#main",
+      "rules": {
+        "no-hard-code-id": false
+      }
+    }
   ]
 }

--- a/.markuplintrc
+++ b/.markuplintrc
@@ -14,6 +14,12 @@
       "rules": {
         "no-hard-code-id": false
       }
+    },
+    {
+      "selector": "Modal > div[onMouseDownCapture][onBlurCapture][onClickCapture]",
+      "rules": {
+        "invalid-attr": false
+      }
     }
   ]
 }

--- a/src/app/(auth)/password/change/_components/current-user-change-password-form/change-password-form/next-action-button/index.tsx
+++ b/src/app/(auth)/password/change/_components/current-user-change-password-form/change-password-form/next-action-button/index.tsx
@@ -28,16 +28,11 @@ export function NextActionButton() {
   }, [from, cleanupQueryParams])
 
   return from === 'account' ? (
-    <Button
-      type="button"
-      className="btn-success"
-      autoFocus={true}
-      onClick={handleClick}
-    >
+    <Button type="button" className="btn-success" onClick={handleClick}>
       このページを閉じる
     </Button>
   ) : (
-    <Link href="/tasks" className="btn btn-success" autoFocus={true}>
+    <Link href="/tasks" className="btn btn-success">
       タスク一覧へ
     </Link>
   )

--- a/src/app/(auth)/password/reset/_components/reset-password-form/reset-password-success-message/index.tsx
+++ b/src/app/(auth)/password/reset/_components/reset-password-form/reset-password-success-message/index.tsx
@@ -50,7 +50,6 @@ export function ResetPasswordSuccessMessage({
         <Button
           type="button"
           className="btn-primary"
-          autoFocus={true}
           status={isSending ? 'pending' : 'idle'}
           onClick={handleClick}
         >

--- a/src/app/(auth)/sign-up/_components/sign-up-form/sign-up-success-message/index.tsx
+++ b/src/app/(auth)/sign-up/_components/sign-up-form/sign-up-success-message/index.tsx
@@ -42,7 +42,6 @@ export function SignUpSuccessMessage({ email, csrfToken }: Props) {
         <Button
           type="button"
           className="btn-primary"
-          autoFocus={true}
           status={isSending ? 'pending' : 'idle'}
           onClick={handleClick}
         >

--- a/src/components/form-controls/label/index.tsx
+++ b/src/components/form-controls/label/index.tsx
@@ -1,8 +1,8 @@
 type LabelProps = Omit<React.ComponentPropsWithoutRef<'label'>, 'className'>
 
-export function Label({ children, ...rest }: LabelProps) {
+export function Label({ children, htmlFor, ...rest }: LabelProps) {
   return (
-    <label className="mb-1 text-sm font-bold" {...rest}>
+    <label className="mb-1 text-sm font-bold" htmlFor={htmlFor} {...rest}>
       {children}
     </label>
   )

--- a/src/components/pages/account-page/current-user-info/editable-email/index.tsx
+++ b/src/components/pages/account-page/current-user-info/editable-email/index.tsx
@@ -136,7 +136,6 @@ export function EditableEmail({
               ref={editorRef}
               type="email"
               defaultValue={emailValue}
-              autoFocus={true}
               register={registerReturn}
               errors={fieldError}
               readOnly={isSubmitting}


### PR DESCRIPTION
### Summary

When running `yarn lint-jsx`, errors and warnings occur.
As preparation for adding to Lefthook's `pre-commit`, fix the areas where errors and warnings occur and make changes to Markuplint settings.

### Changes

- Removed autoFocus (73ac39e081202870d7c1091ee9b9d7649961a2df)
This change resolves the `error: The "autofocus" attribute is disallowed (invalid-attr)`.

- Add htmlFor attribute to the label element in the Label (20c91d21bfb7ae66f43f142cd838c8d28efec67b)
This change resolves the `warning: The "label" element should associate with a control (label-has-control)`.

- Disabled no-hard-code-id for elements with the id `main` (19fa86da510640eacf5b4ce412ce8bee3ff5db62)
This change prevents the `warning: It is hard-coded (no-hard-code-id)` for `src/app/(main)/layout.tsx`.

- Disabled invalid-attr for specific elements (a8fcf7207bbb5452121e19c1e2aa0ec232ce92f2)
This change prevents the following errors for `src/app/(main)/@modal/(.)account/_components/account-modal/index.tsx`:
- `error: The "onMouseDownCapture" attribute is disallowed (invalid-attr)`
- `error: The "onBlurCapture" attribute is disallowed (invalid-attr)`
- `error: The "onBlurCapture" attribute is disallowed (invalid-attr)`
- `error: The "onClickCapture" attribute is disallowed (invalid-attr)`

### Testing

- [x] No errors or warnings are displayed when running `yarn lint-jsx`.
Confirmed that no errors or warnings are output when running `yarn lint-jsx -p` in the terminal.

### Related Issues (Optional)

None

### Notes (Optional)

> [!Warning]
> It is necessary to reconsider assigning `autoFocus` to the appropriate element within the `dialog` element.

- [ \<dialog\>: The Dialog element ](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog)

> [!Warning]
> For the areas where the rules have been disabled and addressed, it is necessary to review the implementation method again.
