### PR TITLE
chore: add Markuplint to Lefthook pre-commit

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -8,6 +8,11 @@ pre-commit:
       run: yarn eslint --fix --max-warnings=0 {staged_files}
       stage_fixed: true
       fail_text: 'Read the report above.'
+    markuplint:
+      glob: 'src/**/*.{jsx,tsx}'
+      run: yarn markuplint --fix {staged_files}
+      stage_fixed: true
+      fail_text: 'Read the report above.'
     prettier:
       run: yarn prettier --write --ignore-unknown {staged_files}
       stage_fixed: true


### PR DESCRIPTION
### Summary

<!-- Briefly describe the purpose of the pull request and the changes it introduces -->
To improve code quality, Markuplint is added to Lefthook's pre-commit.

### Changes

<!-- Explain the specific changes or additions made -->
- Added Markuplint to Lefthook's `pre-commit`.

### Testing

<!-- Describe how the changes were tested to ensure they work as expected -->

- [x] Markuplint is added to Lefthook's `pre-commit`
- [x] `pre-commit` is functioning correctly
I have confirmed that it works correctly with the following steps:

1. Remove `htmlFor` from the `label` element in `src/components/form-controls/label/index.tsx`
2. Stage the changes
3. Run `yarn lefthook run pre-commit` in the terminal

<details>
  <summary>Execution Result</summary>

```shell
node ➜ ~/tascon-frontend (chore/175-add-markuplint-to-lefthook) $ yarn lefthook run pre-commit
╭───────────────────────────────────────╮
│ 🥊 lefthook v1.7.12  hook: pre-commit │
╰───────────────────────────────────────╯
sync hooks: ✔️ (pre-commit, pre-push)
┃  protect-branch ❯ 

chore/175-add-markuplint-to-lefthook

│  markdownlint (skip) no files for inspection
┃  check-logger-trace ❯ 


┃  prettier ❯ 

src/components/form-controls/label/index.tsx 878ms (unchanged)

┃  markuplint ❯ 

<markuplint> warning: The "label" element should associate with a control (label-has-control) /home/node/tascon-frontend/src/components/form-controls/label/index.tsx:5:5
  4: ••return•(
  5: ••••<label className="mb-1 text-sm font-bold" {...rest}>
  6: ••••••{children}

┃  knip-files-exports ❯ 

✂️  Excellent, Knip found no issues.

┃  eslint ❯ 


                                      
  ────────────────────────────────────
summary: (done in 4.40 seconds)       
✔️  protect-branch
✔️  check-logger-trace
✔️  prettier
✔️  knip-files-exports
✔️  eslint
🥊  markuplint: Read the report above.

```

</details>

### Related Issues (Optional)

None

### Notes (Optional)

None
