### PR TITLE
chore: add issue template for bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,56 @@
+name: バグ報告
+description: バグ報告用のテンプレート
+title: '[Bug]: '
+labels: ['bug']
+assignees:
+  - P-manBrown
+body:
+  - type: textarea
+    id: describe_bug
+    attributes:
+      label: 説明
+      description: 可能な限り詳細にバグの内容を説明してください。
+      placeholder: バグの内容を記述してください...
+    validations:
+      required: true
+  - type: textarea
+    id: to_reproduce
+    attributes:
+      label: 再現手順
+      description: バグを再現するための手順を記述してください。
+      placeholder: |
+        1. 〇〇ページにアクセス
+        2. 〇〇ボタンをクリック
+        3. 〇〇のようなエラーが表示される
+    validations:
+      required: true
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: 期待される動作
+      description: どのような動作を期待していたかを説明してください。
+      placeholder: 期待される動作を記述してください...
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: スクリーンショット
+      description: バグについてわかるスクリーンショットを添付してください。
+      placeholder: スクリーンショットを添付してください...
+  - type: textarea
+    id: environment
+    attributes:
+      label: 環境
+      description: バグが発生した環境について記述してください。
+      placeholder: |
+        - OS: [e.g. iOS(v17.6.1)]
+        - Browser: [e.g. chrome(v127.0.6533.101), safari(v17.6)]
+    validations:
+      required: true
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: 追加情報
+      description: 上記以外の追加情報があれば記述してください。
+      placeholder: 追加情報を記述してください...


### PR DESCRIPTION
### Summary

<!-- Briefly describe the purpose of the pull request and the changes it introduces -->
Create an Issue template for bug reports.
This is necessary to report bugs that occurred on the `main` branch.

### Changes

<!-- Explain the specific changes or additions made -->
- Added issue template for bug reports

### Testing

<!-- Describe how the changes were tested to ensure they work as expected -->
- [x] Issue template for bug reports is created.
- [x] Issue template for bug reports is usable.
I have created the same `.github/ISSUE_TEMPLATE/bug.yml` with the same content in another repository and confirmed that it is displayed correctly as shown in the image below.

![New Issue _ P-manBrown_tascon-backend-old](https://github.com/user-attachments/assets/63b69a8b-d791-4c51-a3c9-0231f2a4165c)

### Related Issues (Optional)

None

### Notes (Optional)

None
