### PR TITLE
feat: change the destination of the report issue button to the frontend repo

### DIFF
--- a/src/components/report-issue-link/index.tsx
+++ b/src/components/report-issue-link/index.tsx
@@ -11,7 +11,7 @@ export function ReportIssueLink({ className = '', info }: Props) {
 
   return (
     <a
-      href={`https://github.com/P-manBrown/tascon-backend/issues/new${params}`}
+      href={`https://github.com/P-manBrown/tascon-frontend/issues/new${params}`}
       target="_blank"
       rel="noreferrer"
       className={`link inline-flex items-center ${className}`}

--- a/src/components/report-issue-link/index.tsx
+++ b/src/components/report-issue-link/index.tsx
@@ -6,12 +6,17 @@ type Props = {
 }
 
 export function ReportIssueLink({ className = '', info }: Props) {
-  const body = `※ 以下の値は編集しないでください。\n${info}`
-  const params = info ? `?${new URLSearchParams({ body }).toString()}` : ''
+  const params = new URLSearchParams({
+    title: `[Bug]: タイトル(${info})`,
+    assignee: 'P-manBrown',
+    template: 'bug.yml',
+  }).toString()
+  const issueUrl = 'https://github.com/P-manBrown/tascon-frontend/issues/new'
+  const href = `${issueUrl}${info ? `?${params}` : ''}`
 
   return (
     <a
-      href={`https://github.com/P-manBrown/tascon-frontend/issues/new${params}`}
+      href={href}
       target="_blank"
       rel="noreferrer"
       className={`link inline-flex items-center ${className}`}


### PR DESCRIPTION
### Summary

<!-- Briefly describe the purpose of the pull request and the changes it introduces -->
I have changed the repository for placing documents such as README from the backend repository to the frontend repository.
Therefore, I will change the destination of the "問題を報告" link to the frontend repository.
Additionally, I will ensure that the bug report issue template is used on the destination screen.

### Changes

<!-- Explain the specific changes or additions made -->
- Changed the destination of the report issue link to the frontend repo
This change will make the "問題を報告" link redirect to the issue creation screen of the frontend repository.
- Changed to use the bug report issue template
This change will make the bug report issue template used for issue creation.

### Testing

<!-- Describe how the changes were tested to ensure they work as expected -->
- [x] The transition destination of the problem report button is the issue creation screen of the frontend repository.
- [x] The bug report issue template is being used.
Confirmed that clicking the "問題を報告" link redirects to the image shown below.

![New Issue _ P-manBrown_tascon-frontend · 9 20am · 08-17](https://github.com/user-attachments/assets/5d0b014b-716f-4ae6-83cc-221a710ba05c)

### Related Issues (Optional)

<!-- Mention any related issue numbers (excluding task management issue) -->
None

### Notes (Optional)

<!-- Include any additional information or considerations -->
None
