### PR TITLE
refactor: improve Tailwind CSS classes

### DIFF
--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -4,7 +4,7 @@ type Props = {
 
 export default function AuthLayout({ children }: Props) {
   return (
-    <main className="md:flex md:min-h-[100dvh] md:items-center">
+    <main className="md:flex md:min-h-dvh md:items-center">
       <div className="mx-auto my-12 w-full max-w-md md:my-0 md:border md:shadow-lg md:shadow-black/25">
         <div className="mx-6 md:m-12">{children}</div>
       </div>

--- a/src/app/(auth)/login/_components/login-form/index.tsx
+++ b/src/app/(auth)/login/_components/login-form/index.tsx
@@ -43,7 +43,7 @@ export function LoginForm({ csrfToken }: Props) {
           aria-label={isVisible ? 'パスワードを隠す' : 'パスワードを表示する'}
           onClick={toggleVisible}
         >
-          <VisibilityToggleIcon isVisible={isVisible} className="h-5 w-5" />
+          <VisibilityToggleIcon isVisible={isVisible} className="size-5" />
         </IconButton>
       ),
     },

--- a/src/app/(auth)/password/change/_components/current-user-change-password-form/change-password-form/current-password-input/index.tsx
+++ b/src/app/(auth)/password/change/_components/current-user-change-password-form/change-password-form/current-password-input/index.tsx
@@ -28,7 +28,7 @@ export function CurrentPasswordInput(props: Props) {
             aria-label={isVisible ? 'パスワードを隠す' : 'パスワードを表示する'}
             onClick={toggleVisible}
           >
-            <VisibilityToggleIcon isVisible={isVisible} className="h-5 w-5" />
+            <VisibilityToggleIcon isVisible={isVisible} className="size-5" />
           </IconButton>
         }
         {...props}

--- a/src/app/(auth)/password/change/_components/current-user-change-password-form/change-password-form/index.tsx
+++ b/src/app/(auth)/password/change/_components/current-user-change-password-form/change-password-form/index.tsx
@@ -61,7 +61,7 @@ export function ChangePasswordForm({
     resolver: zodResolver(
       allowPasswordChange
         ? changePasswordSchema.omit({ currentPassword: true })
-        : changePasswordSchema
+        : changePasswordSchema,
     ),
   })
 
@@ -75,7 +75,7 @@ export function ChangePasswordForm({
           type: result.status.toString(),
           message: result.message,
         },
-        { shouldFocus: true }
+        { shouldFocus: true },
       )
     } else {
       openErrorSnackbar(result)
@@ -140,7 +140,7 @@ export function ChangePasswordForm({
                 aria-label="モーダルを閉じる"
                 onClick={closeModal}
               >
-                <XMarkIcon className="h-6 w-6" />
+                <XMarkIcon className="size-6" />
               </IconButton>
             }
           >

--- a/src/app/(auth)/password/change/_components/current-user-change-password-form/change-password-form/new-password-input/index.tsx
+++ b/src/app/(auth)/password/change/_components/current-user-change-password-form/change-password-form/new-password-input/index.tsx
@@ -27,7 +27,7 @@ export function NewPasswordInput(props: Props) {
             aria-label={isVisible ? 'パスワードを隠す' : 'パスワードを表示する'}
             onClick={toggleVisible}
           >
-            <VisibilityToggleIcon isVisible={isVisible} className="h-5 w-5" />
+            <VisibilityToggleIcon isVisible={isVisible} className="size-5" />
           </IconButton>
         }
         {...props}

--- a/src/app/(auth)/password/change/_components/current-user-change-password-form/index.tsx
+++ b/src/app/(auth)/password/change/_components/current-user-change-password-form/index.tsx
@@ -61,7 +61,7 @@ export async function CurrentUserChangePasswordForm() {
 export function LoadingCurrentUserChangePasswordForm() {
   return (
     <div className="flex h-52 items-center justify-center">
-      <Spinner className="h-10 w-10 border-4 border-gray-500" />
+      <Spinner className="size-10 border-4 border-gray-500" />
     </div>
   )
 }

--- a/src/app/(auth)/password/reset/_components/reset-password-form/index.tsx
+++ b/src/app/(auth)/password/reset/_components/reset-password-form/index.tsx
@@ -73,7 +73,7 @@ export function ResetPasswordForm({ csrfToken }: Props) {
                 aria-label="モーダルを閉じる"
                 onClick={closeModal}
               >
-                <XMarkIcon className="h-6 w-6" />
+                <XMarkIcon className="size-6" />
               </IconButton>
             }
           >

--- a/src/app/(auth)/sign-up/_components/sign-up-form/index.tsx
+++ b/src/app/(auth)/sign-up/_components/sign-up-form/index.tsx
@@ -67,7 +67,7 @@ export function SignUpForm({ csrfToken }: Props) {
           aria-label={isVisible ? 'パスワードを隠す' : 'パスワードを表示する'}
           onClick={toggleVisible}
         >
-          <VisibilityToggleIcon isVisible={isVisible} className="h-5 w-5" />
+          <VisibilityToggleIcon isVisible={isVisible} className="size-5" />
         </IconButton>
       ),
     },
@@ -116,7 +116,7 @@ export function SignUpForm({ csrfToken }: Props) {
                 aria-label="モーダルを閉じる"
                 onClick={closeModal}
               >
-                <XMarkIcon className="h-6 w-6" />
+                <XMarkIcon className="size-6" />
               </IconButton>
             }
           >

--- a/src/app/(main)/@modal/(.)account/_components/account-modal/index.tsx
+++ b/src/app/(main)/@modal/(.)account/_components/account-modal/index.tsx
@@ -103,7 +103,7 @@ export function AccountModal({ children }: Props) {
               aria-label="モーダルを閉じる"
               onClick={closeModal}
             >
-              <XMarkIcon className="h-6 w-6" />
+              <XMarkIcon className="size-6" />
             </IconButton>
           }
         >

--- a/src/app/(main)/@modal/(.)users/[id]/_components/user-modal/index.tsx
+++ b/src/app/(main)/@modal/(.)users/[id]/_components/user-modal/index.tsx
@@ -30,7 +30,7 @@ export function UserModal({ children }: Props) {
             aria-label="モーダルを閉じる"
             onClick={closeModal}
           >
-            <XMarkIcon className="h-6 w-6" />
+            <XMarkIcon className="size-6" />
           </IconButton>
         }
       >

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -7,7 +7,7 @@ type Props = {
 
 export default function MainLayout({ children, modal }: Props) {
   return (
-    <div className="flex max-h-[100dvh] flex-col">
+    <div className="flex max-h-dvh flex-col">
       <MainHeader />
       {/* 'id' controls 'overflow-hidden' style on the body element. */}
       <main id="main" className="flex-grow overflow-scroll px-safe">

--- a/src/app/_components/snackbars/snackbar/index.tsx
+++ b/src/app/_components/snackbars/snackbar/index.tsx
@@ -16,8 +16,8 @@ type Props = {
 }
 
 const iconBaseClasses =
-  'inline-flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-md'
-const iconClasses = 'h-6 w-6'
+  'inline-flex size-8 flex-shrink-0 items-center justify-center rounded-md'
+const iconClasses = 'size-6'
 
 export function Snackbar({
   id,
@@ -69,7 +69,7 @@ export function Snackbar({
             onClick={() => closeSnackbar(id)}
             className="hover:bg-white/20"
           >
-            <XMarkIcon className="h-5 w-5 fill-white" />
+            <XMarkIcon className="size-5 fill-white" />
           </IconButton>
         )}
       </div>

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -7,7 +7,7 @@ import type { ErrorProps } from '@/types/error'
 
 export default function Error({ error, reset }: ErrorProps) {
   return (
-    <main className="flex min-h-[100dvh] items-center justify-center max-md:mx-3">
+    <main className="flex min-h-dvh items-center justify-center max-md:mx-3">
       <div className="text-center">
         <p className="text-3xl font-semibold text-red-600 md:text-5xl">Error</p>
         <h1 className="mb-3.5 mt-1.5 text-3xl font-bold tracking-tight md:mb-7 md:mt-3 md:text-6xl">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -31,7 +31,7 @@ export default function RootLayout({ children }: Props) {
   return (
     <html lang="ja">
       {/* 'lg:overflow-hidden' for the route of the main group only. */}
-      <body className="font-body [&:has(dialog:modal)]:overflow-hidden [&:has(main#main)]:overflow-hidden">
+      <body className="font-body has-[dialog:modal]:overflow-hidden has-[main#main]:overflow-hidden">
         {children}
         <Snackbars />
       </body>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -3,7 +3,7 @@ import { NotFoundContent } from '@/components/contents/not-found-content'
 
 export default function NotFound() {
   return (
-    <main className="mx-3 flex min-h-[100dvh] items-center justify-center">
+    <main className="mx-3 flex min-h-dvh items-center justify-center">
       <div className="text-center">
         <p className="text-4xl font-semibold text-red-600 md:text-5xl">404</p>
         <h1 className="mb-5 mt-1.5 text-4xl font-bold tracking-tight md:mt-3 md:text-6xl">

--- a/src/components/collapsible-section/index.tsx
+++ b/src/components/collapsible-section/index.tsx
@@ -75,12 +75,12 @@ export function CollapsibleSection({
         <span className="flex select-none justify-center gap-1 group-hover:stroke-black">
           {isCollapsed ? (
             <>
-              <ChevronDownIcon className="h-4 w-4 self-center" />
+              <ChevronDownIcon className="size-4 self-center" />
               全て表示
             </>
           ) : (
             <>
-              <ChevronUpIcon className="h-4 w-4 self-center" />
+              <ChevronUpIcon className="size-4 self-center" />
               詳細を非表示
             </>
           )}

--- a/src/components/editable-text/index.tsx
+++ b/src/components/editable-text/index.tsx
@@ -90,7 +90,7 @@ export function EditableText({
       ) : (
         <div
           ref={contentRef}
-          className={`relative h-fit [&:has(>button:hover)]:select-none ${
+          className={`relative h-fit has-[>button:hover]:select-none ${
             isDraggingInside ? 'hover:cursor-text' : 'hover:cursor-default'
           }`}
           onMouseEnter={handleMouseEnter}
@@ -99,7 +99,7 @@ export function EditableText({
         >
           {children}
           <button
-            className={`absolute left-0 top-0 h-full w-full rounded-sm duration-200 [&:has(>span)]:hover:bg-black/10 ${
+            className={`absolute left-0 top-0 h-full w-full rounded-sm duration-200 has-[>span]:hover:bg-black/10 ${
               isTextSelected || isDraggingInside ? 'pointer-events-none' : ''
             }`}
             onClick={openEditor}

--- a/src/components/form-controls/checkbox/index.tsx
+++ b/src/components/form-controls/checkbox/index.tsx
@@ -17,7 +17,7 @@ export function Checkbox({
 }: Props) {
   return (
     <label
-      className="block w-fit cursor-pointer focus-visible:outline-offset-4 [&:has(input:disabled)]:cursor-wait"
+      className="block w-fit cursor-pointer focus-visible:outline-offset-4 has-[input:disabled]:cursor-wait"
       onClick={onClick}
       onKeyDown={onKeyDown}
       tabIndex={0}

--- a/src/components/icon-message/index.tsx
+++ b/src/components/icon-message/index.tsx
@@ -10,7 +10,7 @@ type Props = {
   children: React.ReactNode
 }
 
-const iconClasses = 'mx-auto -mt-3 mb-3 h-24 w-24 stroke-1'
+const iconClasses = 'mx-auto -mt-3 mb-3 size-24 stroke-1'
 
 export function IconMessage({ title, severity, children }: Props) {
   const getIcon = () => {

--- a/src/components/layouts/detail-item-heading-layout/index.tsx
+++ b/src/components/layouts/detail-item-heading-layout/index.tsx
@@ -4,7 +4,7 @@ type Props = {
 
 export function DetailItemHeadingLayout({ children }: Props) {
   return (
-    <div className="mb-1.5 [&:has(>:nth-child(2))]:flex [&:has(>:nth-child(2))]:items-center [&:has(>:nth-child(2))]:gap-3">
+    <div className="mb-1.5 has-[>:nth-child(2)]:flex has-[>:nth-child(2)]:items-center has-[>:nth-child(2)]:gap-3">
       {children}
     </div>
   )

--- a/src/components/pages/account-page/current-user-info/change-password-link/index.tsx
+++ b/src/components/pages/account-page/current-user-info/change-password-link/index.tsx
@@ -16,7 +16,7 @@ export function ChangePasswordLink() {
     >
       パスワード変更
       <span className="ml-2">
-        <ArrowTopRightOnSquareIcon className="h-5 w-5 stroke-current" />
+        <ArrowTopRightOnSquareIcon className="size-5 stroke-current" />
       </span>
     </Link>
   )

--- a/src/components/pages/account-page/current-user-info/editable-avatar/index.tsx
+++ b/src/components/pages/account-page/current-user-info/editable-avatar/index.tsx
@@ -66,7 +66,7 @@ export function EditableAvatar({
             status={isDeletingAvatar ? 'pending' : 'idle'}
             onClick={handleXMarkClick}
           >
-            <XCircleIcon className="h-6 w-6 fill-black stroke-white" />
+            <XCircleIcon className="size-6 fill-black stroke-white" />
           </IconButton>
         )}
       </div>

--- a/src/components/pages/account-page/current-user-info/private-mode-switch/toggle-switch/index.tsx
+++ b/src/components/pages/account-page/current-user-info/private-mode-switch/toggle-switch/index.tsx
@@ -8,7 +8,7 @@ const shapeClasses = 'h-6 w-11 rounded-full'
 export function ToggleSwitch({ isToggleOn }: Props) {
   return (
     <span
-      className={`${layoutClasses} ${shapeClasses} flex-shrink-0 p-0.5 after:block after:h-5 after:w-5 after:rounded-full after:border after:border-gray-300 after:bg-white after:transition-all after:content-[''] ${
+      className={`${layoutClasses} ${shapeClasses} flex-shrink-0 p-0.5 after:block after:size-5 after:rounded-full after:border after:border-gray-300 after:bg-white after:transition-all after:content-[''] ${
         isToggleOn ? 'bg-blue-600 after:translate-x-full' : 'bg-gray-200'
       }`}
     />

--- a/src/components/pages/account-page/delete-account-button/index.tsx
+++ b/src/components/pages/account-page/delete-account-button/index.tsx
@@ -69,7 +69,7 @@ export function DeleteAccountButton({ currentUserId, csrfToken }: Props) {
                 aria-label="モーダルを閉じる"
                 onClick={closeModal}
               >
-                <XMarkIcon className="h-6 w-6" />
+                <XMarkIcon className="size-6" />
               </IconButton>
             }
           >

--- a/src/components/report-issue-link/index.tsx
+++ b/src/components/report-issue-link/index.tsx
@@ -24,7 +24,7 @@ export function ReportIssueLink({ className = '', info }: Props) {
     >
       問題を報告
       <span className="ml-0.5">
-        <ArrowTopRightOnSquareIcon className="h-4 w-4" />
+        <ArrowTopRightOnSquareIcon className="size-4" />
       </span>
     </a>
   )


### PR DESCRIPTION
### Summary

<!-- Briefly describe the purpose of the pull request and the changes it introduces -->
The available classes have increased with the update of Tailwind CSS to v3.4.
To improve readability, existing classes will be rewritten to new classes.

### Changes

<!-- Explain the specific changes or additions made -->
- Changed to use `size-*` classes for specifying icon size
- Changed the height specification from `h-[100dvh]` to `h-dvh`
- Changed `[&:has(*)]` to `has-[*]`

The above changes are code-only changes and do not affect the UI display.

### Testing

<!-- Describe how the changes were tested to ensure they work as expected -->
- [x] The relevant classes have been rewritten to the classes available in v3.4 mentioned on [this page](https://tailwindcss.com/blog/tailwindcss-v3-4).
- [x] The UI to be modified is displayed correctly.
The UI to be modified was confirmed to be displayed correctly on Chrome (Mac) and Safari (iPhone).

### Related Issues (Optional)

<!-- Mention any related issue numbers (excluding task management issue) -->
None

### Notes (Optional)

<!-- Include any additional information or considerations -->
None
