### PR TITLE
chore: move pino-pretty configuration to logger.ts

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -5,6 +5,7 @@
     "@evilmartians/lefthook",
     "client-only",
     "@markuplint/jsx-parser",
-    "@markuplint/react-spec"
+    "@markuplint/react-spec",
+    "pino-pretty"
   ]
 }

--- a/next.config.js
+++ b/next.config.js
@@ -10,6 +10,9 @@ const withPWA = require('next-pwa')({
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  experimental: {
+    serverComponentsExternalPackages: ['pino'],
+  },
   reactStrictMode: true,
   images: {
     formats: ['image/avif', 'image/webp'],

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev | pino-pretty",
+    "dev": "next dev",
     "debug": "NODE_OPTIONS='--inspect=0.0.0.0 -r ./.pnp.cjs' next dev",
     "build": "ANALYZE=true next build",
     "start": "next start",

--- a/src/lib/pino/logger.ts
+++ b/src/lib/pino/logger.ts
@@ -1,9 +1,10 @@
 import pino from 'pino'
 import { sendLogWithRetries } from './send-log-with-retries.api'
 
+const isProduction = process.env.NODE_ENV === 'production'
+
 export const logger = pino({
   name: 'tascon-frontend',
-  level: process.env.NODE_ENV === 'production' ? 'info' : 'trace',
   timestamp: pino.stdTimeFunctions.isoTime,
   serializers: {
     err: (err: Error | Record<'err', unknown>) => {
@@ -27,4 +28,17 @@ export const logger = pino({
       },
     },
   },
+  ...(isProduction
+    ? {
+        level: 'info',
+      }
+    : {
+        level: 'trace',
+        transport: {
+          target: 'pino-pretty',
+          options: {
+            colorize: true,
+          },
+        },
+      }),
 })


### PR DESCRIPTION
### Summary

<!-- Briefly describe the purpose of the pull request and the changes it introduces -->
Move the description for using `pino-pretty` from `package.json` to `src/lib/pino/logger.ts`.
This change consolidates the Pino related configuration in src/lib/pino/logger.ts, improving readability.

### Changes

<!-- Explain the specific changes or additions made -->
- Moved pino-pretty config to `src/lib/pino/logger.ts` (74eb2590f215f058e4158e789ec23b23fe2d9e3a)
- Added `pino-pretty` to Kinp's `ignoreDependencies` (adf82b21ccf4ced4d25691ec1bb2233ef79e6949)
This change avoids the Unused devDependencies error for pino-pretty caused by Kinp.

### Testing

<!-- Describe how the changes were tested to ensure they work as expected -->
- [x] The necessary configuration for using `pino-pretty` is moved from `package.json` to `src/lib/pino/logger.ts`.
It has been moved with commit 74eb2590f215f058e4158e789ec23b23fe2d9e.

- [x] Pino logs are organized and displayed in color.
I confirmed this by testing in the terminal, where `pino-pretty` is used for `yarn dev` and not used for `yarn build && yarn start`.

Logs for `yarn dev`

<img width="1262" alt="スクリーンショット 2024-08-19 13 18 48" src="https://github.com/user-attachments/assets/9232b5fd-1846-4cc9-8b89-6750603ea958">

Logs for `yarn build && yarn start`

<img width="1417" alt="スクリーンショット 2024-08-19 12 19 13" src="https://github.com/user-attachments/assets/de415348-3002-444f-8b88-0d83bf740612">


### Related Issues (Optional)

<!-- Mention any related issue numbers (excluding task management issue) -->
None

### Notes (Optional)

<!-- Include any additional information or considerations -->
None
