### PR TITLE
refactor: replace ArrowRightOnRectangleIcon with ArrowRightEndOnRectangleIcon

### DIFF
--- a/src/app/_components/login-link/index.tsx
+++ b/src/app/_components/login-link/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { ArrowRightOnRectangleIcon } from '@heroicons/react/24/solid'
+import { ArrowRightEndOnRectangleIcon } from '@heroicons/react/24/outline'
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
 import { isValidToken } from './is-valid-token.api'
@@ -31,7 +31,7 @@ export function LoginLink() {
         ログイン
       </Link>
       <Link href={isValid ? '/tasks' : '/login'} className="btn-icon lg:hidden">
-        <ArrowRightOnRectangleIcon className="h-8 w-8" />
+        <ArrowRightEndOnRectangleIcon className="h-8 w-8" />
       </Link>
     </div>
   )


### PR DESCRIPTION
### Summary

<!-- Briefly describe the purpose of the pull request and the changes it introduces -->
The `ArrowRightOnRectangleIcon` in heroicons has been deprecated.
Therefore, the login icon will be changed to `ArrowRightEndOnRectangleIcon`.

### Changes

<!-- Explain the specific changes or additions made -->
- Changed the login icon to `ArrowRightEndOnRectangleIcon`. (2b55e9a0754ce1329720029534878ff61deebbf1)
This change will update the login icon in the top right corner of the home screen from `ArrowRightOnRectangleIcon` to `ArrowRightEndOnRectangleIcon`.

### Testing

<!-- Describe how the changes were tested to ensure they work as expected -->
- [x] Replaced `ArrowRightOnRectangleIcon` with `ArrowRightEndOnRectangleIcon`. (2b55e9a0754ce1329720029534878ff61deebbf1)
- [x] Verified that `ArrowRightEndOnRectangleIcon` is displayed correctly.
Confirmed that it is displayed correctly as shown in the image below.

![TASCON](https://github.com/user-attachments/assets/fd616a7c-af49-48d2-afe6-3ceafd7fa61d)

### Related Issues (Optional)

<!-- Mention any related issue numbers (excluding task management issue) -->
None

### Notes (Optional)

<!-- Include any additional information or considerations -->
None
