### PR TITLE
refactor: change the implementation of the resend confirmation email button to use Server Actions

### DIFF
--- a/src/app/(auth)/sign-up/_components/sign-up-form/sign-up-success-message/index.tsx
+++ b/src/app/(auth)/sign-up/_components/sign-up-form/sign-up-success-message/index.tsx
@@ -19,8 +19,7 @@ export function SignUpSuccessMessage({ email, csrfToken }: Props) {
   const handleClick = async () => {
     setIsSending(true)
     const result = await resendConfirmationEmail({ csrfToken, email })
-    if (result instanceof Error) {
-      // @ts-expect-error
+    if (result.status === 'error') {
       openErrorSnackbar(result)
     } else {
       openSnackbar({

--- a/src/app/(auth)/sign-up/_components/sign-up-form/sign-up-success-message/resend-confirmation-email.api.tsx
+++ b/src/app/(auth)/sign-up/_components/sign-up-form/sign-up-success-message/resend-confirmation-email.api.tsx
@@ -1,5 +1,10 @@
+'use server'
+
+import { cookies } from 'next/headers'
 import { z } from 'zod'
+import { ResultObject } from '@/types/api'
 import { fetchData } from '@/utils/api/fetch-data'
+import { createErrorObject } from '@/utils/error/create-error-object'
 import { getRequestId } from '@/utils/request-id/get-request-id'
 import { validateData } from '@/utils/validation/validate-data'
 
@@ -24,25 +29,33 @@ export async function resendConfirmationEmail({
       headers: {
         'Content-Type': 'application/json',
         'X-CSRF-Token': csrfToken,
+        Cookie: cookies().toString(),
       },
       body: JSON.stringify({
         ...bodyData,
         redirect_url: `${process.env.NEXT_PUBLIC_FRONTEND_ORIGIN}/login`,
       }),
-      credentials: 'include',
-    }
+    },
   )
+
+  let resultObject: ResultObject<z.infer<typeof dataSchema>>
+
   if (fetchDataResult instanceof Error) {
-    return fetchDataResult
+    resultObject = createErrorObject(fetchDataResult)
+  } else {
+    const { headers, data } = fetchDataResult
+    const requestId = getRequestId(headers)
+    const validateDataResult = validateData({ requestId, dataSchema, data })
+
+    if (validateDataResult instanceof Error) {
+      resultObject = createErrorObject(validateDataResult)
+    } else {
+      resultObject = {
+        status: 'success',
+        ...validateDataResult,
+      }
+    }
   }
 
-  const { headers, data } = fetchDataResult
-  const requestId = getRequestId(headers)
-
-  const validateDataResult = validateData({ requestId, dataSchema, data })
-  if (validateDataResult instanceof Error) {
-    return validateDataResult
-  }
-
-  return validateDataResult
+  return resultObject
 }

--- a/src/app/(auth)/sign-up/_components/sign-up-form/sign-up-success-message/resend-confirmation-email.api.tsx
+++ b/src/app/(auth)/sign-up/_components/sign-up-form/sign-up-success-message/resend-confirmation-email.api.tsx
@@ -18,6 +18,8 @@ const dataSchema = z.object({
   message: z.string(),
 })
 
+type Data = z.infer<typeof dataSchema>
+
 export async function resendConfirmationEmail({
   csrfToken,
   ...bodyData
@@ -38,7 +40,7 @@ export async function resendConfirmationEmail({
     },
   )
 
-  let resultObject: ResultObject<z.infer<typeof dataSchema>>
+  let resultObject: ResultObject<Data>
 
   if (fetchDataResult instanceof Error) {
     resultObject = createErrorObject(fetchDataResult)

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,0 +1,7 @@
+import type { ErrorObject, Errors } from './error'
+
+export type ResultObject<T extends Record<string, unknown>> =
+  | ({
+      status: 'success'
+    } & T)
+  | ErrorObject<Errors>


### PR DESCRIPTION
### Summary

<!-- Briefly describe the purpose of the pull request and the changes it introduces -->
Currently, CSRF protection is implemented using CSRF tokens. To simplify it further, we want to implement it using an API Key.
To prevent exposing the API Key to the client, requests from the client must use Server Actions.
Change the resend confirmation email button to use Server Actions in preparation for implementing CSRF protection using an API key.

### Changes

<!-- Explain the specific changes or additions made -->
- Changed the resend confirmation email button to use Server Actions (0db0bf7445f0ed94239aae8ded3b0549f848789f)

### Testing

<!-- Describe how the changes were tested to ensure they work as expected -->
- [x] The resend confirmation email button has been changed to use Server Actions.
Changed in commit 0db0bf7445f0ed94239aae8ded3b0549f848789f.

- [x] The resend confirmation email button functions correctly.
Tested the following range in the [test case list](https://docs.google.com/spreadsheets/d/1ESeGIE8ghgZqR0U_RbAJMcV6XgRBxjOQdq2xNooxRjo/edit?usp=sharing):
- From `b-2-2` to `b-3-2`

### Related Issues (Optional)

<!-- Mention any related issue numbers (excluding task management issue) -->
None

### Notes (Optional)

<!-- Include any additional information or considerations -->
None
