### PR TITLE
refactor: change the implementation of reset password to use Server Actions

### DIFF
--- a/src/app/(auth)/password/reset/_components/reset-password-form/reset-password-success-message/index.tsx
+++ b/src/app/(auth)/password/reset/_components/reset-password-form/reset-password-success-message/index.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react'
+import { useErrorSnackbar } from '@/app/_components/snackbars/snackbar/use-error-snackbar'
 import { useSnackbarsStore } from '@/app/_components/snackbars/use-snackbars-store'
 import { Button } from '@/components/buttons/button'
 import { HorizontalRule } from '@/components/horizontal-rule'
 import { IconMessage } from '@/components/icon-message'
-import { HttpError } from '@/utils/error/custom/http-error'
 import { resetPassword } from '../reset-password.api'
 
 type Props = {
@@ -18,17 +18,13 @@ export function ResetPasswordSuccessMessage({
   csrfToken,
 }: Props) {
   const [isSending, setIsSending] = useState(false)
+  const { openErrorSnackbar } = useErrorSnackbar()
   const openSnackbar = useSnackbarsStore((state) => state.openSnackbar)
   const handleClick = async () => {
     setIsSending(true)
     const result = await resetPassword({ csrfToken, email })
-    if (result instanceof Error) {
-      if (result instanceof HttpError) {
-        openSnackbar({
-          severity: 'error',
-          message: `${result.message}`,
-        })
-      }
+    if (result.status === 'error') {
+      openErrorSnackbar(result)
     } else {
       openSnackbar({
         severity: 'success',

--- a/src/app/(auth)/password/reset/_components/reset-password-form/use-reset-password-form.tsx
+++ b/src/app/(auth)/password/reset/_components/reset-password-form/use-reset-password-form.tsx
@@ -4,6 +4,7 @@ import { useForm } from 'react-hook-form'
 import { useErrorSnackbar } from '@/app/_components/snackbars/snackbar/use-error-snackbar'
 import { useModal } from '@/components/modal/use-modal'
 import { resetPasswordSchema } from '@/schemas/request/auth'
+import { ErrorObject } from '@/types/error'
 import { HttpError } from '@/utils/error/custom/http-error'
 import { resetPassword } from './reset-password.api'
 import type { SubmitHandler } from 'react-hook-form'
@@ -43,7 +44,7 @@ export function useResetPasswordForm({
   })
 
   const handleHttpError = useCallback(
-    (err: HttpError) => {
+    (err: ErrorObject<HttpError>) => {
       if (err.message.startsWith('メールアドレス')) {
         setError(
           'email',
@@ -54,7 +55,6 @@ export function useResetPasswordForm({
           { shouldFocus: true },
         )
       } else {
-        // @ts-expect-error
         openErrorSnackbar(err)
       }
     },
@@ -64,11 +64,10 @@ export function useResetPasswordForm({
   const onSubmit: SubmitHandler<ResetPasswordFormValues> = useCallback(
     async (data) => {
       const result = await resetPassword({ csrfToken, ...data })
-      if (result instanceof Error) {
-        if (result instanceof HttpError) {
+      if (result.status === 'error') {
+        if (result.name === 'HttpError') {
           handleHttpError(result)
         } else {
-          // @ts-expect-error
           openErrorSnackbar(result)
         }
       } else {


### PR DESCRIPTION
### Summary

<!-- Briefly describe the purpose of the pull request and the changes it introduces -->
Currently, CSRF protection is implemented using CSRF tokens. To simplify it further, we want to implement it using an API Key.
To prevent exposing the API Key to the client, requests from the client must use Server Actions.
Change  the reset password form and the resend reset password email button to use Server Actions in preparation for implementing CSRF protection using an API key.

### Changes

<!-- Explain the specific changes or additions made -->
- Changed the reset password form and the resend reset password email button to use Server Actions (aeae1c93b4969032e17c6b124e0573fc9f36845a)

### Testing

<!-- Describe how the changes were tested to ensure they work as expected -->
- [x] the reset password form and the resend reset password email button has been changed to use Server Actions.
Changed in commit aeae1c93b4969032e17c6b124e0573fc9f36845a.

- [x] the reset password form and the resend reset password email button functions correctly.
Tested the following range in the [test case list](https://docs.google.com/spreadsheets/d/1ESeGIE8ghgZqR0U_RbAJMcV6XgRBxjOQdq2xNooxRjo/edit?usp=sharing):
- From `d-1` to `d-6`

### Related Issues (Optional)

<!-- Mention any related issue numbers (excluding task management issue) -->
None

### Notes (Optional)

<!-- Include any additional information or considerations -->
None
