### PR TITLE
fix: fix the layout shift on the account page

### DIFF
--- a/src/components/pages/account-page/current-user-info/change-password-link/index.tsx
+++ b/src/components/pages/account-page/current-user-info/change-password-link/index.tsx
@@ -1,23 +1,42 @@
-'use client'
-
 import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/solid'
 import Link from 'next/link'
+import { validateToken } from '@/utils/api/server/validate-token'
 
-export function ChangePasswordLink() {
+const layoutClasses = 'h-12 flex items-center'
+
+export async function ChangePasswordLink() {
+  const validateTokenResult = await validateToken()
+  if (validateTokenResult instanceof Error) {
+    throw validateTokenResult
+  }
+  const { provider } = validateTokenResult.data
+
+  const isEmailProvider = provider === 'email'
+
   return (
-    <Link
-      href={{
-        pathname: '/password/change',
-        query: { from: 'account' },
-      }}
-      target="_blank"
-      rel="noreferrer"
-      className="btn btn-success"
-    >
-      パスワード変更
-      <span className="ml-2">
-        <ArrowTopRightOnSquareIcon className="size-5 stroke-current" />
-      </span>
-    </Link>
+    <div className={layoutClasses}>
+      {isEmailProvider ? (
+        <Link
+          href={{
+            pathname: '/password/change',
+            query: { from: 'account' },
+          }}
+          target="_blank"
+          rel="noreferrer"
+          className="btn btn-success"
+        >
+          パスワードを変更
+          <span className="ml-2">
+            <ArrowTopRightOnSquareIcon className="size-5 stroke-current" />
+          </span>
+        </Link>
+      ) : (
+        <p>SNS認証を使用しているため、パスワードの変更はできません。</p>
+      )}
+    </div>
   )
+}
+
+export function LoadingChangePasswordLink() {
+  return <div className={`skeleton ${layoutClasses}`} />
 }

--- a/src/components/pages/account-page/current-user-info/index.tsx
+++ b/src/components/pages/account-page/current-user-info/index.tsx
@@ -1,17 +1,13 @@
-import { redirect } from 'next/navigation'
 import { Suspense } from 'react'
-import { LoadingAvatar } from '@/components/avatars/avatar'
 import { DetailItemHeading } from '@/components/headings/detail-item-heading'
 import { DetailItemContentLayout } from '@/components/layouts/detail-item-content-layout'
 import { DetailItemHeadingLayout } from '@/components/layouts/detail-item-heading-layout'
 import { Tag } from '@/components/tag'
-import { LoadingDetailMultiLineText } from '@/components/texts/detail-multi-line-text'
-import { LoadingDetailSingleLineText } from '@/components/texts/detail-single-line-text'
-import { validateToken } from '@/utils/api/server/validate-token'
 import { getCsrfToken } from '@/utils/cookie/get-csrf-token'
-import { HttpError } from '@/utils/error/custom/http-error'
-import { generateRedirectLoginPath } from '@/utils/login-path/generate-redirect-login-path.server'
-import { ChangePasswordLink } from './change-password-link'
+import {
+  ChangePasswordLink,
+  LoadingChangePasswordLink,
+} from './change-password-link'
 import { EditableAvatar, LoadingEditableAvatar } from './editable-avatar'
 import { EditableBio, LoadingEditableBio } from './editable-bio'
 import { LoadingEditableEmail, EditableEmail } from './editable-email'
@@ -20,28 +16,8 @@ import {
   LoadingPrivateModeSwitch,
   PrivateModeSwitch,
 } from './private-mode-switch'
-import { LoadingToggleSwitch } from './private-mode-switch/private-mode-checkbox/toggle-switch'
 
-export async function CurrentUserInfo() {
-  const handleHttpError = (err: HttpError) => {
-    if (err.status === 401) {
-      const redirectLoginPath = generateRedirectLoginPath()
-      redirect(redirectLoginPath)
-    }
-
-    throw err
-  }
-
-  const validateTokenResult = await validateToken()
-  if (validateTokenResult instanceof Error) {
-    if (validateTokenResult instanceof HttpError) {
-      handleHttpError(validateTokenResult)
-    }
-
-    throw validateTokenResult
-  }
-  const { data: currentUser } = validateTokenResult
-
+export function CurrentUserInfo() {
   const getCsrfTokenResult = getCsrfToken()
   if (getCsrfTokenResult instanceof Error) {
     throw getCsrfTokenResult
@@ -75,56 +51,15 @@ export async function CurrentUserInfo() {
           </Suspense>
         </DetailItemContentLayout>
       </div>
-      {currentUser.provider === 'email' && <ChangePasswordLink />}
-    </>
-  )
-}
-
-export function LoadingCurrentUserInfo() {
-  return (
-    <>
-      <div className="flex justify-center">
-        <LoadingAvatar size={128} />
-      </div>
       <div>
         <DetailItemHeadingLayout>
-          <DetailItemHeading>ユーザー名</DetailItemHeading>
-          <Tag color="gray">公開</Tag>
-        </DetailItemHeadingLayout>
-        <DetailItemContentLayout>
-          <LoadingDetailSingleLineText />
-        </DetailItemContentLayout>
-      </div>
-      <div>
-        <DetailItemHeadingLayout>
-          <DetailItemHeading>自己紹介</DetailItemHeading>
-          <Tag color="gray">公開</Tag>
-        </DetailItemHeadingLayout>
-        <div style={{ height: '160px' }}>
-          <DetailItemContentLayout>
-            <LoadingDetailMultiLineText lines={6} />
-          </DetailItemContentLayout>
-        </div>
-      </div>
-      <div>
-        <DetailItemHeadingLayout>
-          <DetailItemHeading>メールアドレス</DetailItemHeading>
+          <DetailItemHeading>パスワード</DetailItemHeading>
           <Tag color="gray">非公開</Tag>
         </DetailItemHeadingLayout>
         <DetailItemContentLayout>
-          <LoadingDetailSingleLineText />
-        </DetailItemContentLayout>
-      </div>
-      <div>
-        <DetailItemHeadingLayout>
-          <DetailItemHeading>プライベートモード</DetailItemHeading>
-          <Tag color="gray">非公開</Tag>
-        </DetailItemHeadingLayout>
-        <DetailItemContentLayout>
-          <LoadingToggleSwitch />
-          <span className="ml-3 align-middle">
-            メールアドレスでの検索・登録を拒否する
-          </span>
+          <Suspense fallback={<LoadingChangePasswordLink />}>
+            <ChangePasswordLink />
+          </Suspense>
         </DetailItemContentLayout>
       </div>
     </>

--- a/src/components/pages/account-page/index.tsx
+++ b/src/components/pages/account-page/index.tsx
@@ -1,11 +1,10 @@
 import { redirect } from 'next/navigation'
-import { Suspense } from 'react'
 import { HorizontalRule } from '@/components/horizontal-rule'
 import { getCsrfToken } from '@/utils/cookie/get-csrf-token'
 import { getCurrentUserId } from '@/utils/cookie/get-current-user-id'
 import { generateRedirectLoginPath } from '@/utils/login-path/generate-redirect-login-path.server'
 import { AccountQueryParamSnackbar } from './account-query-param-snackbar'
-import { CurrentUserInfo, LoadingCurrentUserInfo } from './current-user-info'
+import { CurrentUserInfo } from './current-user-info'
 import { DeleteAccountButton } from './delete-account-button'
 import { LogoutButton } from './logout-button'
 
@@ -25,9 +24,7 @@ export function AccountPage() {
 
   return (
     <div className="flex flex-col gap-y-10">
-      <Suspense fallback={<LoadingCurrentUserInfo />}>
-        <CurrentUserInfo />
-      </Suspense>
+      <CurrentUserInfo />
       <HorizontalRule />
       <LogoutButton csrfToken={csrfToken} />
       <DeleteAccountButton


### PR DESCRIPTION
### Summary

<!-- Briefly describe the purpose of the pull request and the changes it introduces -->
Currently, when a user who is not using SNS authentication logs in and opens the `/account` page, a layout shift occurs due to the link to `/password/change`.

![Screen Recording 2024-10-19 18 21 17](https://github.com/user-attachments/assets/cd0bfe2d-418b-4860-ae9d-70ad03c68603)

To resolve the above issue, the display method of the link to the `/password/change` page on the `/account` page is changed.

### Changes

<!-- Explain the specific changes or additions made -->
- Changed the display method of the link to the `/password/change` page (7e50bfd4de97d83ab93553795dac4109e32bdaab)

This change improves the layout shift when the `/account` page is displayed.

### Testing

<!-- Describe how the changes were tested to ensure they work as expected -->
- [x] No layout shift occurs when opening the `/account` page
- [x] The `/account` page is displayed correctly
As shown in the image below, it was confirmed that the `/account` page is displayed correctly without any layout shift.

- Email login user
![画面収録 2024-10-20 16 17 56](https://github.com/user-attachments/assets/80a595e2-862e-40ef-a016-028dc86cc15c)

- Social login user
![画面収録 2024-10-20 16 25 56](https://github.com/user-attachments/assets/7d7de753-f94d-41cb-86bf-534a370afa08)

### Related Issues (Optional)

<!-- Mention any related issue numbers (excluding task management issue) -->
None

### Notes (Optional)

<!-- Include any additional information or considerations -->
None
