### PR TITLE
refactor: change the implementation of the logout button to use Server Actions

### DIFF
--- a/src/components/pages/account-page/logout-button/index.tsx
+++ b/src/components/pages/account-page/logout-button/index.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { useRouter } from 'next/navigation'
 import { useId, useState } from 'react'
 import { useErrorSnackbar } from '@/app/_components/snackbars/snackbar/use-error-snackbar'
 import { Button } from '@/components/buttons/button'
@@ -13,18 +12,13 @@ type Props = {
 export function LogoutButton({ csrfToken }: Props) {
   const id = useId()
   const [isLoggingOut, setIsLoggingOut] = useState(false)
-  const router = useRouter()
   const { openErrorSnackbar } = useErrorSnackbar()
 
   const handleClick = async () => {
     setIsLoggingOut(true)
     const result = await logout(csrfToken)
-    if (result instanceof Error) {
-      // @ts-expect-error
+    if (result.status === 'error') {
       openErrorSnackbar(result)
-    } else {
-      router.refresh()
-      router.push('/')
     }
     setIsLoggingOut(false)
   }

--- a/src/components/pages/account-page/logout-button/logout.api.ts
+++ b/src/components/pages/account-page/logout-button/logout.api.ts
@@ -1,18 +1,53 @@
+'use server'
+
+import { cookies } from 'next/headers'
+import { redirect } from 'next/navigation'
+import { z } from 'zod'
+import { ResultObject } from '@/types/api'
 import { fetchData } from '@/utils/api/fetch-data'
+import { proxyServerCookies } from '@/utils/cookie/proxy-server-cookies'
+import { createErrorObject } from '@/utils/error/create-error-object'
+import { getRequestId } from '@/utils/request-id/get-request-id'
+import { validateData } from '@/utils/validation/validate-data'
+
+const dataSchema = z.object({
+  success: z.literal(true),
+})
+
+type Data = z.infer<typeof dataSchema>
 
 export async function logout(csrfToken: string) {
-  const result = await fetchData(
+  const fetchDataResult = await fetchData(
     `${process.env.NEXT_PUBLIC_API_ORIGIN}/api/v1/auth/sign_out`,
     {
       method: 'DELETE',
       headers: {
         'X-CSRF-Token': csrfToken,
+        Cookie: cookies().toString(),
       },
-      credentials: 'include',
-    }
+    },
   )
 
-  if (result instanceof Error) {
-    return result
+  let resultObject: ResultObject<Data>
+
+  if (fetchDataResult instanceof Error) {
+    resultObject = createErrorObject(fetchDataResult)
+  } else {
+    const { headers, data } = fetchDataResult
+    const requestId = getRequestId(headers)
+    const validateDataResult = validateData({ requestId, dataSchema, data })
+
+    if (validateDataResult instanceof Error) {
+      resultObject = createErrorObject(validateDataResult)
+    } else {
+      resultObject = {
+        status: 'success',
+        ...validateDataResult,
+      }
+      proxyServerCookies(headers)
+      redirect('/')
+    }
   }
+
+  return resultObject
 }


### PR DESCRIPTION
### Summary

<!-- Briefly describe the purpose of the pull request and the changes it introduces -->
Currently, CSRF protection is implemented using CSRF tokens. To simplify it further, we want to implement it using an API Key.
To prevent exposing the API Key to the client, requests from the client must use Server Actions.
Change the logout button to use Server Actions in preparation for implementing CSRF protection using an API key.

### Changes

<!-- Explain the specific changes or additions made -->
- Change the logout button to use Server Actions (8ea26dd1f788d91076e664e8a0d9279c20d7a332)

### Testing

<!-- Describe how the changes were tested to ensure they work as expected -->
- [x] the logout button has been changed to use Server Actions.
Confirmed that [`logout.api.ts`](https://github.com/P-manBrown/tascon-frontend/commit/8ea26dd1f788d91076e664e8a0d9279c20d7a332#diff-3373a42e286b92e07877927e160876e9adbd7717aa293dfd0569f0cf3eb4ced4R1) has been changed to use Server Actions.

- [x] the logout button functions correctly.
Tested the following range in the [test case list](https://docs.google.com/spreadsheets/d/1ESeGIE8ghgZqR0U_RbAJMcV6XgRBxjOQdq2xNooxRjo/edit?usp=sharing):
- `f-8-1`
- `f-15-1`

### Related Issues (Optional)

<!-- Mention any related issue numbers (excluding task management issue) -->
None

### Notes (Optional)

<!-- Include any additional information or considerations -->
None
