### PR TITLE
refactor: change the implementation of the login link to use Server Actions

### DIFF
--- a/src/app/_components/login-link/index.tsx
+++ b/src/app/_components/login-link/index.tsx
@@ -3,7 +3,7 @@
 import { ArrowRightEndOnRectangleIcon } from '@heroicons/react/24/outline'
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
-import { isValidToken } from './is-valid-token.api'
+import { validateToken } from './validate-token.api'
 
 export function LoginLink() {
   const [isValid, setIsValid] = useState(false)
@@ -11,9 +11,9 @@ export function LoginLink() {
   useEffect(() => {
     let ignore = false
     void (async () => {
-      const isValid = await isValidToken()
-      if (!ignore) {
-        setIsValid(isValid)
+      const result = await validateToken()
+      if (!ignore && result.status === 'success') {
+        setIsValid(true)
       }
     })()
 

--- a/src/app/_components/login-link/validate-token.api.ts
+++ b/src/app/_components/login-link/validate-token.api.ts
@@ -6,7 +6,7 @@ export async function isValidToken() {
     {
       method: 'GET',
       credentials: 'include',
-    }
+    },
   )
 
   const isValid = !(result instanceof Error)

--- a/src/app/_components/login-link/validate-token.api.ts
+++ b/src/app/_components/login-link/validate-token.api.ts
@@ -1,14 +1,50 @@
-import { fetchData } from '@/utils/api/fetch-data'
+'use server'
 
-export async function isValidToken() {
-  const result = await fetchData(
-    `${process.env.NEXT_PUBLIC_API_ORIGIN}/api/v1/auth/validate_token`,
+import camelcaseKeys, { CamelCaseKeys } from 'camelcase-keys'
+import { cookies } from 'next/headers'
+import { z } from 'zod'
+import { validateTokenDataSchema } from '@/schemas/response/validate-token-success'
+import { ResultObject } from '@/types/api'
+import { fetchData } from '@/utils/api/fetch-data'
+import { createErrorObject } from '@/utils/error/create-error-object'
+import { getRequestId } from '@/utils/request-id/get-request-id'
+import { validateData } from '@/utils/validation/validate-data'
+
+type Data = CamelCaseKeys<z.infer<typeof validateTokenDataSchema>, true>
+
+export async function validateToken() {
+  const fetchDataResult = await fetchData(
+    `${process.env.API_ORIGIN}/api/v1/auth/validate_token`,
     {
       method: 'GET',
-      credentials: 'include',
+      headers: {
+        Cookie: cookies().toString(),
+      },
     },
   )
 
-  const isValid = !(result instanceof Error)
-  return isValid
+  let resultObject: ResultObject<Data>
+
+  if (fetchDataResult instanceof Error) {
+    resultObject = createErrorObject(fetchDataResult)
+  } else {
+    const { headers, data } = fetchDataResult
+    const requestId = getRequestId(headers)
+    const validateDataResult = validateData({
+      requestId,
+      dataSchema: validateTokenDataSchema,
+      data,
+    })
+
+    if (validateDataResult instanceof Error) {
+      resultObject = createErrorObject(validateDataResult)
+    } else {
+      resultObject = {
+        status: 'success',
+        ...camelcaseKeys(validateDataResult, { deep: true }),
+      }
+    }
+  }
+
+  return resultObject
 }


### PR DESCRIPTION
### Summary
<!-- Briefly describe the purpose of the pull request and the changes it introduces -->
As preparation for implementing CSRF protection using an API key, we have modified forms and similar elements to use Server Actions. To enhance readability and facilitate maintenance, we will use Server Actions for all requests to the API. Therefore, we will also change the authentication check request for the login link to use Server Actions.

### Changes

<!-- Explain the specific changes or additions made -->
- Change the login link to use Server Actions (ad73f4e8e4da588eb75dfebebf364cc9a3325d4b)

### Testing

<!-- Describe how the changes were tested to ensure they work as expected -->
- [x] The login link has been changed to use Server Actions.
Confirmed that [`validate-token.api.ts`](https://github.com/P-manBrown/tascon-frontend/commit/ad73f4e8e4da588eb75dfebebf364cc9a3325d4b#diff-3e102adfe341c940fc7af82ccaf10217f3f050ae03cf779b1540abd6463ab357R1) has been changed to use Server Actions.

- [x] The login link functions correctly.
Tested the following range in the [test case list](https://docs.google.com/spreadsheets/d/1ESeGIE8ghgZqR0U_RbAJMcV6XgRBxjOQdq2xNooxRjo/edit?usp=sharing):
  - From `a-3-1` to `a-3-2`

### Related Issues (Optional)

<!-- Mention any related issue numbers (excluding task management issue) -->
None

### Notes (Optional)

<!-- Include any additional information or considerations -->
None
