### PR TITLE
refactor: modify change-avatar.api.ts to execute revalidatePath only upon successful requests

### DIFF
--- a/src/components/pages/account-page/current-user-info/editable-avatar/avatar-editor/change-avatar.api.ts
+++ b/src/components/pages/account-page/current-user-info/editable-avatar/avatar-editor/change-avatar.api.ts
@@ -58,10 +58,9 @@ export async function changeAvatar({ csrfToken, formData }: Params) {
       resultObject = createErrorObject(validateDataResult)
     } else {
       resultObject = camelcaseKeys(validateDataResult, { deep: true })
+      revalidatePath('/account')
     }
   }
-
-  revalidatePath('/account')
 
   return resultObject
 }


### PR DESCRIPTION
### Summary

<!-- Briefly describe the purpose of the pull request and the changes it introduces -->
Currently, `change-avatar.api.ts` executes `revalidatePath` even when the request fails. (change-avatar.api.ts#L64)
Since the avatar image is not changed when the request fails, revalidating the page is unnecessary.
Therefore, I will modify `change-avatar.api.ts` to execute `revalidatePath` only when the request is successful.

### Changes

<!-- Explain the specific changes or additions made -->
- Modify `change-avatar.api.ts` to execute `revalidatePath` only upon successful requests.

### Testing

<!-- Describe how the changes were tested to ensure they work as expected -->
- [x] `change-avatar.api.ts` is modified to execute `revalidatePath` only when the request is successful
  [Change in revalidatePath](https://github.com/P-manBrown/tascon-frontend/blob/ae361b17d8476dca4291f4c76c861876e79fa2fe/src/components/pages/account-page/current-user-info/editable-avatar/avatar-editor/change-avatar.api.ts#L61)

- [x] The avatar can be changed successfully
  Tested the following range in the [test case list](https://docs.google.com/spreadsheets/d/1ESeGIE8ghgZqR0U_RbAJMcV6XgRBxjOQdq2xNooxRjo/edit?usp=sharing):
  - `f-2-3`, `f-2-4`
  - `f-10-4`, `f-10-5`, `f-10-6`
  
### Related Issues (Optional)

<!-- Mention any related issue numbers (excluding task management issue) -->
None

### Notes (Optional)

<!-- Include any additional information or considerations -->
None

