### PR TITLE
refactor: change the redirect process in the server actions to be executed on the client

### DIFF
--- a/src/app/(auth)/password/change/_components/current-user-change-password-form/change-password-form/change-password.api.ts
+++ b/src/app/(auth)/password/change/_components/current-user-change-password-form/change-password-form/change-password.api.ts
@@ -3,15 +3,12 @@
 import camelcaseKeys from 'camelcase-keys'
 import { revalidatePath } from 'next/cache'
 import { cookies } from 'next/headers'
-import { redirect } from 'next/navigation'
 import snakecaseKeys from 'snakecase-keys'
 import { z } from 'zod'
 import { authSchema } from '@/schemas/response/auth'
 import { ResultObject } from '@/types/api'
 import { fetchData } from '@/utils/api/fetch-data'
 import { createErrorObject } from '@/utils/error/create-error-object'
-import { HttpError } from '@/utils/error/custom/http-error'
-import { generateRedirectLoginPath } from '@/utils/login-path/generate-redirect-login-path.server'
 import { getRequestId } from '@/utils/request-id/get-request-id'
 import { validateData } from '@/utils/validation/validate-data'
 import type { CamelCaseKeys } from 'camelcase-keys'
@@ -50,13 +47,6 @@ export async function changePassword({ csrfToken, ...bodyData }: Params) {
   let resultObject: ResultObject<Data>
 
   if (fetchDataResult instanceof Error) {
-    const isHttpError = fetchDataResult instanceof HttpError
-    const isUnauthorized = isHttpError && fetchDataResult.statusCode === 401
-    if (isUnauthorized) {
-      const redirectLoginPath = generateRedirectLoginPath()
-      redirect(redirectLoginPath)
-    }
-
     resultObject = createErrorObject(fetchDataResult)
   } else {
     const { headers, data } = fetchDataResult

--- a/src/app/(auth)/password/change/_components/current-user-change-password-form/change-password-form/index.tsx
+++ b/src/app/(auth)/password/change/_components/current-user-change-password-form/change-password-form/index.tsx
@@ -2,6 +2,7 @@
 
 import { XMarkIcon } from '@heroicons/react/24/solid'
 import { zodResolver } from '@hookform/resolvers/zod'
+import { useRouter } from 'next/navigation'
 import { useForm } from 'react-hook-form'
 import { useErrorSnackbar } from '@/app/_components/snackbars/snackbar/use-error-snackbar'
 import { Button } from '@/components/buttons/button'
@@ -12,6 +13,7 @@ import { useModal } from '@/components/modal/use-modal'
 import { changePasswordSchema } from '@/schemas/request/auth'
 import { ErrorObject } from '@/types/error'
 import { HttpError } from '@/utils/error/custom/http-error'
+import { useRedirectLoginPath } from '@/utils/login-path/use-redirect-login-path'
 import { changePassword } from './change-password.api'
 import { CurrentPasswordInput } from './current-password-input'
 import { NewPasswordInput } from './new-password-input'
@@ -38,6 +40,8 @@ export function ChangePasswordForm({
   successMessage,
   csrfToken,
 }: Props) {
+  const router = useRouter()
+  const redirectLoginPath = useRedirectLoginPath()
   const { openErrorSnackbar } = useErrorSnackbar()
   const {
     shouldMount,
@@ -64,7 +68,10 @@ export function ChangePasswordForm({
   })
 
   const handleHttpError = (err: ErrorObject<HttpError>) => {
-    if (err.message.startsWith('現在のパスワード')) {
+    if (err.statusCode === 401) {
+      router.push(redirectLoginPath)
+      router.refresh()
+    } else if (err.message.startsWith('現在のパスワード')) {
       setError(
         'currentPassword',
         {

--- a/src/components/pages/account-page/delete-current-user-account-button/delete-account-button/delete-account.api.ts
+++ b/src/components/pages/account-page/delete-current-user-account-button/delete-account-button/delete-account.api.ts
@@ -1,11 +1,9 @@
 'use server'
 
 import { cookies } from 'next/headers'
-import { redirect } from 'next/navigation'
 import { z } from 'zod'
 import { ResultObject } from '@/types/api'
 import { fetchData } from '@/utils/api/fetch-data'
-import { proxyServerCookies } from '@/utils/cookie/proxy-server-cookies'
 import { createErrorObject } from '@/utils/error/create-error-object'
 import { getRequestId } from '@/utils/request-id/get-request-id'
 import { validateData } from '@/utils/validation/validate-data'
@@ -43,8 +41,6 @@ export async function deleteAccount(csrfToken: string) {
       resultObject = createErrorObject(validateDataResult)
     } else {
       resultObject = validateDataResult
-      proxyServerCookies(headers)
-      redirect('https://forms.gle/F9d8j2XnjT2mAfRc9')
     }
   }
 

--- a/src/components/pages/account-page/delete-current-user-account-button/delete-account-button/index.tsx
+++ b/src/components/pages/account-page/delete-current-user-account-button/delete-account-button/index.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { XMarkIcon } from '@heroicons/react/24/solid'
+import { useRouter } from 'next/navigation'
 import { useId, useState } from 'react'
 import { useErrorSnackbar } from '@/app/_components/snackbars/snackbar/use-error-snackbar'
 import { Button } from '@/components/buttons/button'
@@ -18,8 +19,9 @@ type Props = {
 }
 
 export function DeleteAccountButton({ currentUserId, csrfToken }: Props) {
-  const [isDeletingAccount, setIsDeletingAccount] = useState(false)
+  const router = useRouter()
   const id = useId()
+  const [isDeletingAccount, setIsDeletingAccount] = useState(false)
   const { openErrorSnackbar } = useErrorSnackbar()
   const {
     shouldMount,
@@ -39,6 +41,9 @@ export function DeleteAccountButton({ currentUserId, csrfToken }: Props) {
     } else {
       cleanupLocalStorage(currentUserId)
       closeModal()
+      window.open('https://forms.gle/F9d8j2XnjT2mAfRc9', '_blank', 'noreferrer')
+      router.push('/')
+      router.refresh()
     }
     setIsDeletingAccount(false)
   }

--- a/src/components/pages/account-page/logout-button/index.tsx
+++ b/src/components/pages/account-page/logout-button/index.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useRouter } from 'next/navigation'
 import { useId, useState } from 'react'
 import { useErrorSnackbar } from '@/app/_components/snackbars/snackbar/use-error-snackbar'
 import { Button } from '@/components/buttons/button'
@@ -10,6 +11,7 @@ type Props = {
 }
 
 export function LogoutButton({ csrfToken }: Props) {
+  const router = useRouter()
   const id = useId()
   const [isLoggingOut, setIsLoggingOut] = useState(false)
   const { openErrorSnackbar } = useErrorSnackbar()
@@ -19,6 +21,8 @@ export function LogoutButton({ csrfToken }: Props) {
     const result = await logout(csrfToken)
     if (result.status === 'error') {
       openErrorSnackbar(result)
+    } else {
+      router.push('/')
     }
     setIsLoggingOut(false)
   }

--- a/src/components/pages/account-page/logout-button/logout.api.ts
+++ b/src/components/pages/account-page/logout-button/logout.api.ts
@@ -1,7 +1,6 @@
 'use server'
 
 import { cookies } from 'next/headers'
-import { redirect } from 'next/navigation'
 import { z } from 'zod'
 import { ResultObject } from '@/types/api'
 import { fetchData } from '@/utils/api/fetch-data'
@@ -45,7 +44,6 @@ export async function logout(csrfToken: string) {
         ...validateDataResult,
       }
       proxyServerCookies(headers)
-      redirect('/')
     }
   }
 


### PR DESCRIPTION
### Summary

<!-- Briefly describe the purpose of the pull request and the changes it introduces -->
Currently, there is a mix of using `useRouter()` and `redirect()` for post-request redirection.
To improve maintainability, post-request redirection will be unified to use `useRouter()`.

### Changes

<!-- Explain the specific changes or additions made -->
- Perform unauthenticated redirect on the client side during password change (561fe4d42e25bdbbd07c37dd52f884e26000e7ee)
- Perform redirect on the client side during account deletion (42411cdc38a98e543ed3070257c29f323c03d92d)
- Perform client-side redirect on logout (116d22364886ac824b4e9f7bc096121e97ed6129)

### Testing

<!-- Describe how the changes were tested to ensure they work as expected -->
- [x] Post-request redirection is unified to use `useRouter()`
- [x] Redirection works correctly
Tested the following range in the [test case list](https://docs.google.com/spreadsheets/d/1ESeGIE8ghgZqR0U_RbAJMcV6XgRBxjOQdq2xNooxRjo/edit?usp=sharing):
- `e-2-1`
- `e-17-1`
- `f-8-1`
- `f-9-5`

### Related Issues (Optional)

<!-- Mention any related issue numbers (excluding task management issue) -->
None

### Notes (Optional)

<!-- Include any additional information or considerations -->
None
