### PR TITLE
refactor: change NEXT_PUBLIC_API_ORIGIN to API_ORIGIN in server actions

### DIFF
--- a/src/app/(auth)/login/_components/login-form/login.api.ts
+++ b/src/app/(auth)/login/_components/login-form/login.api.ts
@@ -30,7 +30,7 @@ type Data = CamelCaseKeys<z.infer<typeof dataSchema>, true>
 
 export async function login({ csrfToken, ...bodyData }: Params) {
   const fetchDataResult = await fetchData(
-    `${process.env.NEXT_PUBLIC_API_ORIGIN}/api/v1/auth/sign_in`,
+    `${process.env.API_ORIGIN}/api/v1/auth/sign_in`,
     {
       method: 'POST',
       headers: {

--- a/src/app/(auth)/password/reset/_components/reset-password-form/reset-password.api.ts
+++ b/src/app/(auth)/password/reset/_components/reset-password-form/reset-password.api.ts
@@ -23,7 +23,7 @@ type Data = z.infer<typeof dataSchema>
 
 export async function resetPassword({ csrfToken, ...bodyData }: Params) {
   const fetchDataResult = await fetchData(
-    `${process.env.NEXT_PUBLIC_API_ORIGIN}/api/v1/auth/password`,
+    `${process.env.API_ORIGIN}/api/v1/auth/password`,
     {
       method: 'POST',
       headers: {

--- a/src/app/(auth)/sign-up/_components/sign-up-form/sign-up-success-message/resend-confirmation-email.api.ts
+++ b/src/app/(auth)/sign-up/_components/sign-up-form/sign-up-success-message/resend-confirmation-email.api.ts
@@ -25,7 +25,7 @@ export async function resendConfirmationEmail({
   ...bodyData
 }: Params) {
   const fetchDataResult = await fetchData(
-    `${process.env.NEXT_PUBLIC_API_ORIGIN}/api/v1/auth/confirmation`,
+    `${process.env.API_ORIGIN}/api/v1/auth/confirmation`,
     {
       method: 'POST',
       headers: {

--- a/src/app/(auth)/sign-up/_components/sign-up-form/sign-up.api.ts
+++ b/src/app/(auth)/sign-up/_components/sign-up-form/sign-up.api.ts
@@ -27,7 +27,7 @@ type Data = CamelCaseKeys<z.infer<typeof dataSchema>, true>
 
 export async function signUp({ csrfToken, ...bodyData }: Params) {
   const fetchDataResult = await fetchData(
-    `${process.env.NEXT_PUBLIC_API_ORIGIN}/api/v1/auth`,
+    `${process.env.API_ORIGIN}/api/v1/auth`,
     {
       method: 'POST',
       headers: {

--- a/src/components/pages/account-page/current-user-info/editable-avatar/avatar-editor/change-avatar.api.ts
+++ b/src/components/pages/account-page/current-user-info/editable-avatar/avatar-editor/change-avatar.api.ts
@@ -33,7 +33,7 @@ export async function changeAvatar({ csrfToken, formData }: Params) {
   }
 
   const fetchDataResult = await fetchData(
-    `${process.env.NEXT_PUBLIC_API_ORIGIN}/api/v1/auth`,
+    `${process.env.API_ORIGIN}/api/v1/auth`,
     {
       method: 'PATCH',
       headers: reqHeaders,

--- a/src/components/pages/account-page/current-user-info/editable-bio/bio-editor/change-bio.api.ts
+++ b/src/components/pages/account-page/current-user-info/editable-bio/bio-editor/change-bio.api.ts
@@ -17,7 +17,7 @@ type Params = {
 
 export async function changeBio({ csrfToken, ...bodyData }: Params) {
   const fetchDataResult = await fetchData(
-    `${process.env.NEXT_PUBLIC_API_ORIGIN}/api/v1/auth`,
+    `${process.env.API_ORIGIN}/api/v1/auth`,
     {
       method: 'PATCH',
       headers: {

--- a/src/components/pages/account-page/current-user-info/editable-email/email-editor/change-email.api.ts
+++ b/src/components/pages/account-page/current-user-info/editable-email/email-editor/change-email.api.ts
@@ -18,7 +18,7 @@ type Params = {
 
 export async function changeEmail({ csrfToken, ...bodyData }: Params) {
   const fetchDataResult = await fetchData(
-    `${process.env.NEXT_PUBLIC_API_ORIGIN}/api/v1/auth`,
+    `${process.env.API_ORIGIN}/api/v1/auth`,
     {
       method: 'PATCH',
       headers: {

--- a/src/components/pages/account-page/current-user-info/editable-name/name-editor/change-name.api.ts
+++ b/src/components/pages/account-page/current-user-info/editable-name/name-editor/change-name.api.ts
@@ -17,7 +17,7 @@ type Params = {
 
 export async function changeName({ csrfToken, ...bodyData }: Params) {
   const fetchDataResult = await fetchData(
-    `${process.env.NEXT_PUBLIC_API_ORIGIN}/api/v1/auth`,
+    `${process.env.API_ORIGIN}/api/v1/auth`,
     {
       method: 'PATCH',
       headers: {

--- a/src/components/pages/account-page/current-user-info/private-mode-switch/private-mode-checkbox/change-is-private.api.ts
+++ b/src/components/pages/account-page/current-user-info/private-mode-switch/private-mode-checkbox/change-is-private.api.ts
@@ -18,7 +18,7 @@ type Params = {
 
 export async function changeIsPrivate({ csrfToken, ...bodyData }: Params) {
   const fetchDataResult = await fetchData(
-    `${process.env.NEXT_PUBLIC_API_ORIGIN}/api/v1/auth`,
+    `${process.env.API_ORIGIN}/api/v1/auth`,
     {
       method: 'PATCH',
       headers: {

--- a/src/components/pages/account-page/delete-current-user-account-button/delete-account-button/delete-account.api.ts
+++ b/src/components/pages/account-page/delete-current-user-account-button/delete-account-button/delete-account.api.ts
@@ -17,7 +17,7 @@ type Data = z.infer<typeof dataSchema>
 
 export async function deleteAccount(csrfToken: string) {
   const fetchDataResult = await fetchData(
-    `${process.env.NEXT_PUBLIC_API_ORIGIN}/api/v1/auth`,
+    `${process.env.API_ORIGIN}/api/v1/auth`,
     {
       method: 'DELETE',
       headers: {

--- a/src/components/pages/account-page/logout-button/logout.api.ts
+++ b/src/components/pages/account-page/logout-button/logout.api.ts
@@ -17,7 +17,7 @@ type Data = z.infer<typeof dataSchema>
 
 export async function logout(csrfToken: string) {
   const fetchDataResult = await fetchData(
-    `${process.env.NEXT_PUBLIC_API_ORIGIN}/api/v1/auth/sign_out`,
+    `${process.env.API_ORIGIN}/api/v1/auth/sign_out`,
     {
       method: 'DELETE',
       headers: {


### PR DESCRIPTION
### Summary

<!-- Briefly describe the purpose of the pull request and the changes it introduces -->
`NEXT_PUBLIC_API_ORIGIN` is being used within Server Actions. However, since it is not exposed to the client, `API_ORIGIN` is more appropriate.
Therefore, change `NEXT_PUBLIC_API_ORIGIN` to` API_ORIGIN` in Server Actions.

### Changes

<!-- Explain the specific changes or additions made -->
- Change `NEXT_PUBLIC_API_ORIGIN` to `API_ORIGIN` in server actions

### Testing

<!-- Describe how the changes were tested to ensure they work as expected -->
- [x] `NEXT_PUBLIC_API_ORIGIN` in Server Actions is changed to `API_ORIGIN`
- [x] Server Actions can successfully make requests to the API
Tested the following range in the [test case list](https://docs.google.com/spreadsheets/d/1ESeGIE8ghgZqR0U_RbAJMcV6XgRBxjOQdq2xNooxRjo/edit?usp=sharing):
- `b-2-1`
- `b-2-2`
- `c-2-1`
- `d-1-1`
- `d-1-2`
- `e-2-1`
- `f-2-3`
- `f-2-4`
- `f-3-3`

### Related Issues (Optional)

<!-- Mention any related issue numbers (excluding task management issue) -->
None

### Notes (Optional)

<!-- Include any additional information or considerations -->
None
