### PR TITLE
refactor: remove status from HttpError

### DIFF
--- a/src/components/pages/user-page/index.tsx
+++ b/src/components/pages/user-page/index.tsx
@@ -25,10 +25,10 @@ const avatarSize = 128
 
 export async function UserPage({ id }: Props) {
   const handleHttpError = (err: HttpError) => {
-    if (err.status === 401) {
+    if (err.statusCode === 401) {
       const redirectLoginPath = generateRedirectLoginPath()
       redirect(redirectLoginPath)
-    } else if (err.status === 404) {
+    } else if (err.statusCode === 404) {
       notFound()
     }
 

--- a/src/utils/api/fetch-data.ts
+++ b/src/utils/api/fetch-data.ts
@@ -19,7 +19,7 @@ type Options = Omit<RequestInit, 'method'> & {
 
 export async function fetchData(
   url: string,
-  { headers, ...optionRest }: Options
+  { headers, ...optionRest }: Options,
 ) {
   const requestId = crypto.randomUUID()
 
@@ -37,7 +37,7 @@ export async function fetchData(
 
     logger.debug(
       { requestId, method: optionRest.method, url, data },
-      'fetchData response data'
+      'fetchData response data',
     )
 
     if (!res.ok) {
@@ -70,11 +70,11 @@ export async function fetchData(
     }
 
     if (err instanceof HttpError) {
-      if ([401, 404, 422].includes(err.status)) {
+      if ([401, 404, 422].includes(err.statusCode)) {
         logger.warn(err)
-      } else if (400 <= err.status && err.status < 500) {
+      } else if (400 <= err.statusCode && err.statusCode < 500) {
         logger.error(err)
-      } else if (err.status >= 500) {
+      } else if (err.statusCode >= 500) {
         logger.fatal(err)
       }
       return err

--- a/src/utils/error/custom/http-error.ts
+++ b/src/utils/error/custom/http-error.ts
@@ -8,13 +8,11 @@ export class HttpError extends Error {
   name: 'HttpError'
   requestId: string
   statusCode: number
-  status: number // TODO: Remove this property in the future
 
   constructor({ requestId, res, message }: Params) {
     super(message ?? 'リクエストの処理中にエラーが発生しました。')
     this.name = 'HttpError'
     this.requestId = requestId
     this.statusCode = res.status
-    this.status = res.status // TODO: Remove this property in the future
   }
 }


### PR DESCRIPTION
### Summary

<!-- Briefly describe the purpose of the pull request and the changes it introduces -->
The `HttpError` class currently includes both `status` and `statusCode` to manage status codes returned from the API.
To improve maintainability, we need to standardize on `statusCode`. Therefore, we will remove `status` from `HttpError`.

### Changes

<!-- Explain the specific changes or additions made -->
- Remove `status` from `HttpError`
- Replace occurrences of `status` with `statusCode` to fix type errors

### Testing

<!-- Describe how the changes were tested to ensure they work as expected -->
- [x] `status` has been removed from `HttpError`
- [x] No TypeScript errors are present
  Verified that `yarn build` completes successfully.

```shell
node ➜ ~/tascon-frontend (refactor/320-remove-status-from-http-error) $ yarn build                                    
  ▲ Next.js 14.2.15
  - Environments: .env.local, .env

   Creating an optimized production build ...
> [PWA] Compile server
> [PWA] Compile server
> [PWA] Compile client (static)
> [PWA] Auto register service worker with: /home/node/tascon-frontend/node_modules/next-pwa/register.js
> [PWA] Service worker: /home/node/tascon-frontend/public/sw.js
> [PWA]   url: /sw.js
> [PWA]   scope: /
Webpack Bundle Analyzer saved report to /home/node/tascon-frontend/.next/analyze/nodejs.html
Webpack Bundle Analyzer saved report to /home/node/tascon-frontend/.next/analyze/edge.html
Browserslist: caniuse-lite is outdated. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
Webpack Bundle Analyzer saved report to /home/node/tascon-frontend/.next/analyze/client.html
 ✓ Compiled successfully
 ✓ Linting and checking validity of types    
 ✓ Collecting page data    
 ✓ Generating static pages (13/13)
 ✓ Collecting build traces    
 ✓ Finalizing page optimization    

Route (app)                              Size     First Load JS
┌ ○ /                                    1.97 kB         104 kB
├ ○ /_not-found                          164 B          87.3 kB
├ ƒ /(.)account                          146 B           134 kB
├ ƒ /(.)users/[id]                       297 B          92.5 kB
├ ƒ /account                             147 B           134 kB
├ ƒ /api/log                             0 B                0 B
├ ƒ /login                               4.11 kB         123 kB
├ ƒ /password/change                     4.95 kB         124 kB
├ ƒ /password/reset                      4.69 kB         123 kB
├ ƒ /sign-up                             5.71 kB         124 kB
├ ƒ /tasks                               164 B          87.3 kB
├ ƒ /templates                           164 B          87.3 kB
├ ƒ /users                               164 B          87.3 kB
└ ƒ /users/[id]                          297 B          92.5 kB
+ First Load JS shared by all            87.1 kB
  ├ chunks/117-c79b7965bc9f8535.js       31.6 kB
  ├ chunks/fd9d1056-f1ca4b40cf5bde72.js  53.6 kB
  └ other shared chunks (total)          1.89 kB


ƒ Middleware                             46.5 kB

○  (Static)   prerendered as static content
ƒ  (Dynamic)  server-rendered on demand
```

### Related Issues (Optional)

<!-- Mention any related issue numbers (excluding task management issue) -->
None

### Notes (Optional)

<!-- Include any additional information or considerations -->
None
