### PR TITLE
feat: redirect to the login page if the status code of the logout response is 404

### DIFF
--- a/src/components/pages/account-page/logout-button/index.tsx
+++ b/src/components/pages/account-page/logout-button/index.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/navigation'
 import { useId, useState } from 'react'
 import { useErrorSnackbar } from '@/app/_components/snackbars/snackbar/use-error-snackbar'
 import { Button } from '@/components/buttons/button'
+import { useRedirectLoginPath } from '@/utils/login-path/use-redirect-login-path'
 import { logout } from './logout.api'
 
 type Props = {
@@ -13,6 +14,7 @@ type Props = {
 export function LogoutButton({ csrfToken }: Props) {
   const router = useRouter()
   const id = useId()
+  const redirectLoginPath = useRedirectLoginPath()
   const [isLoggingOut, setIsLoggingOut] = useState(false)
   const { openErrorSnackbar } = useErrorSnackbar()
 
@@ -20,6 +22,10 @@ export function LogoutButton({ csrfToken }: Props) {
     setIsLoggingOut(true)
     const result = await logout(csrfToken)
     if (result.status === 'error') {
+      if (result.name === 'HttpError' && result.statusCode === 404) {
+        router.push(redirectLoginPath)
+        router.refresh()
+      }
       openErrorSnackbar(result)
     } else {
       router.push('/')


### PR DESCRIPTION
### Summary

<!-- Briefly describe the purpose of the pull request and the changes it introduces -->
When the logout response status code is 404, an error snackbar is displayed.
However, it is unclear what to do next, and it is inconsistent with other requests.
Like other requests on the account page, redirect to `/login` when the status code is 404.

### Changes

<!-- Explain the specific changes or additions made -->
- Redirect to login page if logout response is 404

### Testing

<!-- Describe how the changes were tested to ensure they work as expected -->
- [x] Redirect to `/login` when the status code is 404
Tested the following range in the [test case list](https://docs.google.com/spreadsheets/d/1ESeGIE8ghgZqR0U_RbAJMcV6XgRBxjOQdq2xNooxRjo/edit?usp=sharing):
- `f-15-2`

### Related Issues (Optional)

<!-- Mention any related issue numbers (excluding task management issue) -->
None

### Notes (Optional)

<!-- Include any additional information or considerations -->
None
