### PR TITLE
feat: redirect to the login page if the status code of the delete account response is 404

### DIFF
--- a/src/components/pages/account-page/delete-current-user-account-button/delete-account-button/index.tsx
+++ b/src/components/pages/account-page/delete-current-user-account-button/delete-account-button/index.tsx
@@ -10,6 +10,7 @@ import { ModalContent } from '@/components/contents/modal-content'
 import { IconMessage } from '@/components/icon-message'
 import { Modal } from '@/components/modal'
 import { useModal } from '@/components/modal/use-modal'
+import { useRedirectLoginPath } from '@/utils/login-path/use-redirect-login-path'
 import { cleanupLocalStorage } from './cleanup-local-storage'
 import { deleteAccount } from './delete-account.api'
 
@@ -21,6 +22,7 @@ type Props = {
 export function DeleteAccountButton({ currentUserId, csrfToken }: Props) {
   const router = useRouter()
   const id = useId()
+  const redirectLoginPath = useRedirectLoginPath()
   const [isDeletingAccount, setIsDeletingAccount] = useState(false)
   const { openErrorSnackbar } = useErrorSnackbar()
   const {
@@ -37,7 +39,12 @@ export function DeleteAccountButton({ currentUserId, csrfToken }: Props) {
     setIsDeletingAccount(true)
     const result = await deleteAccount(csrfToken)
     if (result.status === 'error') {
-      openErrorSnackbar(result)
+      if (result.name === 'HttpError' && result.statusCode === 404) {
+        router.push(redirectLoginPath)
+        router.refresh()
+      } else {
+        openErrorSnackbar(result)
+      }
     } else {
       cleanupLocalStorage(currentUserId)
       closeModal()

--- a/src/components/pages/account-page/logout-button/index.tsx
+++ b/src/components/pages/account-page/logout-button/index.tsx
@@ -25,8 +25,9 @@ export function LogoutButton({ csrfToken }: Props) {
       if (result.name === 'HttpError' && result.statusCode === 404) {
         router.push(redirectLoginPath)
         router.refresh()
+      } else {
+        openErrorSnackbar(result)
       }
-      openErrorSnackbar(result)
     } else {
       router.push('/')
     }


### PR DESCRIPTION
### Summary

<!-- Briefly describe the purpose of the pull request and the changes it introduces -->
When the delete account response status code is 404, an error snackbar is displayed.
However, it is unclear what to do next, and it is inconsistent with other requests.
Like other requests on the account page, redirect to `/login` when the status code is 404.

### Changes

<!-- Explain the specific changes or additions made -->
- Redirect to login page if delete account response is 404

### Testing

<!-- Describe how the changes were tested to ensure they work as expected -->
- [x] Redirect to `/login` when the status code is 404
Tested the following range in the [test case list](https://docs.google.com/spreadsheets/d/1ESeGIE8ghgZqR0U_RbAJMcV6XgRBxjOQdq2xNooxRjo/edit?usp=sharing):
- `f-16-2`

### Related Issues (Optional)

<!-- Mention any related issue numbers (excluding task management issue) -->
None

### Notes (Optional)

<!-- Include any additional information or considerations -->
None
