### PR TITLE
feat: delete authentication cookies when an account is deleted

### DIFF
--- a/src/components/pages/account-page/delete-current-user-account-button/delete-account-button/delete-account.api.ts
+++ b/src/components/pages/account-page/delete-current-user-account-button/delete-account-button/delete-account.api.ts
@@ -4,6 +4,7 @@ import { cookies } from 'next/headers'
 import { z } from 'zod'
 import { ResultObject } from '@/types/api'
 import { fetchData } from '@/utils/api/fetch-data'
+import { proxyServerCookies } from '@/utils/cookie/proxy-server-cookies'
 import { createErrorObject } from '@/utils/error/create-error-object'
 import { getRequestId } from '@/utils/request-id/get-request-id'
 import { validateData } from '@/utils/validation/validate-data'
@@ -41,6 +42,7 @@ export async function deleteAccount(csrfToken: string) {
       resultObject = createErrorObject(validateDataResult)
     } else {
       resultObject = validateDataResult
+      proxyServerCookies(headers)
     }
   }
 

--- a/src/components/pages/account-page/delete-current-user-account-button/delete-account-button/index.tsx
+++ b/src/components/pages/account-page/delete-current-user-account-button/delete-account-button/index.tsx
@@ -50,7 +50,6 @@ export function DeleteAccountButton({ currentUserId, csrfToken }: Props) {
       closeModal()
       window.open('https://forms.gle/F9d8j2XnjT2mAfRc9', '_blank', 'noreferrer')
       router.push('/')
-      router.refresh()
     }
     setIsDeletingAccount(false)
   }


### PR DESCRIPTION
### Summary

<!-- Briefly describe the purpose of the pull request and the changes it introduces -->
The backend has been updated to delete the authentication cookie (auth_cookie) when an account is deleted.
To ensure the deletion of the authentication cookie is reflected on the client side, the account deletion process has been modified.

### Changes

<!-- Explain the specific changes or additions made -->
- Delete auth cookies on account deletion

### Testing

<!-- Describe how the changes were tested to ensure they work as expected -->
- [x] The authentication cookie is deleted upon account deletion.
  Tested the following range in the [test case list](https://docs.google.com/spreadsheets/d/1ESeGIE8ghgZqR0U_RbAJMcV6XgRBxjOQdq2xNooxRjo/edit?usp=sharing):
  - `f-9-5`

### Related Issues (Optional)

<!-- Mention any related issue numbers (excluding task management issue) -->
None

### Notes (Optional)

<!-- Include any additional information or considerations -->
None

