### PR TITLE
fix: fix layout shift on login and sign-up screens

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -3,15 +3,23 @@ import { Suspense } from 'react'
 import { AuthHeading } from '@/components/headings/auth-heading'
 import { HorizontalRule } from '@/components/horizontal-rule'
 import { SocialLoginForms } from '@/components/social-login-forms'
+import { getFromUrl } from '@/utils/url/get-from-url'
 import { LoginForm } from './_components/login-form'
 import { LoginQueryParamSnackbar } from './_components/login-query-param-snackbar'
+import type { SearchParams } from '@/types/page'
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
   title: 'ログイン',
 }
 
-export default function Login() {
+type Props = {
+  searchParams: SearchParams
+}
+
+export default function Login({ searchParams }: Props) {
+  const fromUrl = getFromUrl(searchParams)
+
   return (
     <>
       <AuthHeading className="mb-7">ログイン</AuthHeading>
@@ -20,9 +28,7 @@ export default function Login() {
       </Suspense>
       <HorizontalRule className="my-8">または</HorizontalRule>
       <div className="space-y-8">
-        <Suspense>
-          <SocialLoginForms />
-        </Suspense>
+        <SocialLoginForms fromUrl={fromUrl} />
       </div>
       <div className="mt-10 text-center">
         <Link href="/sign-up" className="link">

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -3,10 +3,9 @@ import { Suspense } from 'react'
 import { AuthHeading } from '@/components/headings/auth-heading'
 import { HorizontalRule } from '@/components/horizontal-rule'
 import { SocialLoginForms } from '@/components/social-login-forms'
-import { getFromUrl } from '@/utils/url/get-from-url'
 import { LoginForm } from './_components/login-form'
 import { LoginQueryParamSnackbar } from './_components/login-query-param-snackbar'
-import type { SearchParams } from '@/types/page'
+import type { PageSearchParams } from '@/types/page'
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
@@ -14,11 +13,14 @@ export const metadata: Metadata = {
 }
 
 type Props = {
-  searchParams: SearchParams
+  searchParams: PageSearchParams
 }
 
 export default function Login({ searchParams }: Props) {
-  const fromUrl = getFromUrl(searchParams)
+  let fromUrl = searchParams.from_url
+  if (typeof fromUrl !== 'string') {
+    fromUrl = undefined
+  }
 
   return (
     <>

--- a/src/app/(auth)/password/forgot/_components/forgot-password-query-param-snackbar/index.tsx
+++ b/src/app/(auth)/password/forgot/_components/forgot-password-query-param-snackbar/index.tsx
@@ -3,9 +3,10 @@
 import { useEffect } from 'react'
 import { useSnackbarsStore } from '@/app/_components/snackbars/use-snackbars-store'
 import { useQueryParams } from '@/utils/query-param/use-query-params'
+import type { SearchParams } from '@/types/page'
 
 type Props = {
-  searchParams: { [key: string]: string | string[] | undefined }
+  searchParams: SearchParams
 }
 
 export function ForgotPasswordQueryParamSnackbar({ searchParams }: Props) {

--- a/src/app/(auth)/password/forgot/_components/forgot-password-query-param-snackbar/index.tsx
+++ b/src/app/(auth)/password/forgot/_components/forgot-password-query-param-snackbar/index.tsx
@@ -3,10 +3,10 @@
 import { useEffect } from 'react'
 import { useSnackbarsStore } from '@/app/_components/snackbars/use-snackbars-store'
 import { useQueryParams } from '@/utils/query-param/use-query-params'
-import type { SearchParams } from '@/types/page'
+import type { PageSearchParams } from '@/types/page'
 
 type Props = {
-  searchParams: SearchParams
+  searchParams: PageSearchParams
 }
 
 export function ForgotPasswordQueryParamSnackbar({ searchParams }: Props) {

--- a/src/app/(auth)/password/forgot/page.tsx
+++ b/src/app/(auth)/password/forgot/page.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link'
 import { AuthHeading } from '@/components/headings/auth-heading'
 import { ForgotPasswordQueryParamSnackbar } from './_components/forgot-password-query-param-snackbar'
 import { RequestResetPasswordEmailForm } from './_components/request-reset-password-email-form'
+import type { SearchParams } from '@/types/page'
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
@@ -9,7 +10,7 @@ export const metadata: Metadata = {
 }
 
 type Props = {
-  searchParams: { [key: string]: string | string[] | undefined }
+  searchParams: SearchParams
 }
 
 export default function ForgotPassword({ searchParams }: Props) {

--- a/src/app/(auth)/password/forgot/page.tsx
+++ b/src/app/(auth)/password/forgot/page.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link'
 import { AuthHeading } from '@/components/headings/auth-heading'
 import { ForgotPasswordQueryParamSnackbar } from './_components/forgot-password-query-param-snackbar'
 import { RequestResetPasswordEmailForm } from './_components/request-reset-password-email-form'
-import type { SearchParams } from '@/types/page'
+import type { PageSearchParams } from '@/types/page'
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
 }
 
 type Props = {
-  searchParams: SearchParams
+  searchParams: PageSearchParams
 }
 
 export default function ForgotPassword({ searchParams }: Props) {

--- a/src/app/(auth)/sign-up/page.tsx
+++ b/src/app/(auth)/sign-up/page.tsx
@@ -1,25 +1,30 @@
 import Link from 'next/link'
-import { Suspense } from 'react'
 import { AuthHeading } from '@/components/headings/auth-heading'
 import { HorizontalRule } from '@/components/horizontal-rule'
 import { SocialLoginForms } from '@/components/social-login-forms'
+import { getFromUrl } from '@/utils/url/get-from-url'
 import { SignUpForm } from './_components/sign-up-form'
+import type { SearchParams } from '@/types/page'
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
   title: '新規登録',
 }
 
-export default function SignUp() {
+type Props = {
+  searchParams: SearchParams
+}
+
+export default function SignUp({ searchParams }: Props) {
+  const fromUrl = getFromUrl(searchParams)
+
   return (
     <>
       <AuthHeading className="mb-7">新規登録</AuthHeading>
       <SignUpForm />
       <HorizontalRule className="my-6">または</HorizontalRule>
       <div className="space-y-6">
-        <Suspense>
-          <SocialLoginForms />
-        </Suspense>
+        <SocialLoginForms fromUrl={fromUrl} />
       </div>
       <div className="mt-7 text-center">
         <Link href="/login" className="link">

--- a/src/app/(auth)/sign-up/page.tsx
+++ b/src/app/(auth)/sign-up/page.tsx
@@ -2,29 +2,21 @@ import Link from 'next/link'
 import { AuthHeading } from '@/components/headings/auth-heading'
 import { HorizontalRule } from '@/components/horizontal-rule'
 import { SocialLoginForms } from '@/components/social-login-forms'
-import { getFromUrl } from '@/utils/url/get-from-url'
 import { SignUpForm } from './_components/sign-up-form'
-import type { SearchParams } from '@/types/page'
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
   title: '新規登録',
 }
 
-type Props = {
-  searchParams: SearchParams
-}
-
-export default function SignUp({ searchParams }: Props) {
-  const fromUrl = getFromUrl(searchParams)
-
+export default function SignUp() {
   return (
     <>
       <AuthHeading className="mb-7">新規登録</AuthHeading>
       <SignUpForm />
       <HorizontalRule className="my-6">または</HorizontalRule>
       <div className="space-y-6">
-        <SocialLoginForms fromUrl={fromUrl} />
+        <SocialLoginForms />
       </div>
       <div className="mt-7 text-center">
         <Link href="/login" className="link">

--- a/src/components/social-login-forms/index.tsx
+++ b/src/components/social-login-forms/index.tsx
@@ -13,9 +13,13 @@ const socialLoginForms = [
 ]
 const apiBaseUrl = `${process.env.NEXT_PUBLIC_API_ORIGIN}/api/v1/auth`
 
-export function SocialLoginForms() {
+type Props = {
+  fromUrl: string | undefined
+}
+
+export function SocialLoginForms({ fromUrl }: Props) {
   const { activeProvider, authActionText, handleClick, windowName } =
-    useSocialLoginForms()
+    useSocialLoginForms({ fromUrl })
 
   return (
     <>

--- a/src/components/social-login-forms/index.tsx
+++ b/src/components/social-login-forms/index.tsx
@@ -14,7 +14,7 @@ const socialLoginForms = [
 const apiBaseUrl = `${process.env.NEXT_PUBLIC_API_ORIGIN}/api/v1/auth`
 
 type Props = {
-  fromUrl: string | undefined
+  fromUrl?: string
 }
 
 export function SocialLoginForms({ fromUrl }: Props) {

--- a/src/components/social-login-forms/use-social-login-forms.tsx
+++ b/src/components/social-login-forms/use-social-login-forms.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import camelcaseKeys from 'camelcase-keys'
-import { usePathname, useSearchParams } from 'next/navigation'
+import { usePathname } from 'next/navigation'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { z } from 'zod'
 import { useErrorSnackbar } from '@/app/_components/snackbars/snackbar/use-error-snackbar'
@@ -13,6 +13,10 @@ import { getPostLoginUrl } from '@/utils/url/get-post-login-url'
 import { validateData } from '@/utils/validation/validate-data'
 import { storeCredentials } from './store-credentials.action'
 import type { CamelCaseKeys } from 'camelcase-keys'
+
+type Params = {
+  fromUrl: string | undefined
+}
 
 const messageSchema = z.object({
   request_id: z.string(),
@@ -44,10 +48,9 @@ type HandleAuthFailureParams = {
 
 const windowName = 'socialLoginWindow'
 
-export const useSocialLoginForms = () => {
+export const useSocialLoginForms = ({ fromUrl }: Params) => {
   const pathname = usePathname()
   const authActionText = pathname === '/sign-up' ? '新規登録' : 'ログイン'
-  const searchParams = useSearchParams()
   const openSnackbar = useSnackbarsStore((state) => state.openSnackbar)
   const { openErrorSnackbar } = useErrorSnackbar()
   const [activeProvider, setActiveProvider] = useState('')
@@ -116,7 +119,6 @@ export const useSocialLoginForms = () => {
       if (result.status === 'error') {
         openErrorSnackbar(result)
       } else {
-        const fromUrl = searchParams.get('from_url')
         const targetUrl = getPostLoginUrl(fromUrl)
         // Using router.push() causes the page displaying the modal to become Not Found.
         location.assign(targetUrl)
@@ -124,7 +126,7 @@ export const useSocialLoginForms = () => {
 
       setActiveProvider('')
     },
-    [openErrorSnackbar, searchParams],
+    [openErrorSnackbar, fromUrl],
   )
 
   const handleMessage = useCallback(

--- a/src/types/page.ts
+++ b/src/types/page.ts
@@ -1,0 +1,3 @@
+export type SearchParams = {
+  [key: string]: string | string[] | undefined
+}

--- a/src/types/page.ts
+++ b/src/types/page.ts
@@ -1,3 +1,3 @@
-export type SearchParams = {
+export type PageSearchParams = {
   [key: string]: string | string[] | undefined
 }

--- a/src/utils/url/get-from-url.ts
+++ b/src/utils/url/get-from-url.ts
@@ -1,0 +1,8 @@
+import type { SearchParams } from '@/types/page'
+
+export function getFromUrl(searchParams: SearchParams) {
+  const fromUrl = searchParams.from_url
+  if (typeof fromUrl === 'string') {
+    return fromUrl
+  }
+}

--- a/src/utils/url/get-from-url.ts
+++ b/src/utils/url/get-from-url.ts
@@ -1,8 +1,0 @@
-import type { SearchParams } from '@/types/page'
-
-export function getFromUrl(searchParams: SearchParams) {
-  const fromUrl = searchParams.from_url
-  if (typeof fromUrl === 'string') {
-    return fromUrl
-  }
-}

--- a/src/utils/url/get-post-login-url.ts
+++ b/src/utils/url/get-post-login-url.ts
@@ -1,6 +1,6 @@
 const origin = process.env.NEXT_PUBLIC_FRONTEND_ORIGIN
 
-export function getPostLoginUrl(fromUrl: string | null) {
+export function getPostLoginUrl(fromUrl: string | null | undefined) {
   let targetUrl = `${origin}/tasks`
 
   if (fromUrl && URL.canParse(fromUrl)) {


### PR DESCRIPTION
### Summary

<!-- Briefly describe the purpose of the pull request and the changes it introduces -->
As mentioned in #415 and #416, layout shifts occur during rendering on the sign-up and login screens. To fix this, the method of obtaining `fromUrl` in `SocialLoginForms` will be changed.

### Changes

<!-- Explain the specific changes or additions made -->
- Changed the method of obtaining `fromUrl` from using `useSearchParams` to passing it as a `props` from the Page component (bbb2f02fbe7a7a31f1dbb90b83ca911e4b1076b1, 8b3bf660e93bce453b2783ae483aef99f44b5d9e). This change eliminates the need to wrap `SocialLoginForms` with `Suspense`, thereby fixing the layout shifts in the sign-up and login screens.
- Use `SearchParams` type for the `searchParams` prop (fba1047e394253975bcafde445d056f8147c4c77)

### Testing

<!-- Describe how the changes were tested to ensure they work as expected -->
- Confirmed that the layout shifts on the sign-up and login screens are fixed as follows.  
![画面収録 2024-12-20 11 47 58](https://github.com/user-attachments/assets/437f00b4-cb6f-4b1b-bc70-5e7145ea1dd8)
![画面収録 2024-12-20 11 48 49](https://github.com/user-attachments/assets/9e6e0974-a6e7-4e9f-8bc6-25125e2eb709)

- Tested the following range in the [test case list](https://docs.google.com/spreadsheets/d/1ESeGIE8ghgZqR0U_RbAJMcV6XgRBxjOQdq2xNooxRjo/edit?usp=sharing):
  - `c-5-2`

### Related Issues (Optional)

<!-- Mention any related issue numbers (excluding task management issue) -->
Closes: #416

### Notes (Optional)

<!-- Include any additional information or considerations -->
None
