### PR TITLE
feat: change the resetPasswordToken cookie to be sent only on /password/reset

### DIFF
--- a/src/components/pages/account-page/current-user-info/current-user-change-password-form-show-button/change-password-form-show-button/change-password.api.ts
+++ b/src/components/pages/account-page/current-user-info/current-user-change-password-form-show-button/change-password-form-show-button/change-password.api.ts
@@ -1,7 +1,6 @@
 'use server'
 
 import camelcaseKeys from 'camelcase-keys'
-import { cookies } from 'next/headers'
 import snakecaseKeys from 'snakecase-keys'
 import { z } from 'zod'
 import { authSchema } from '@/schemas/response/auth'
@@ -58,7 +57,6 @@ export async function changePassword(bodyData: Params) {
         status: 'success',
         ...camelcaseKeys(validateDataResult, { deep: true }),
       }
-      cookies().delete('resetPasswordToken')
     }
   }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -38,6 +38,7 @@ export async function middleware(req: NextRequest) {
         value: resetPasswordToken,
         httpOnly: true,
         sameSite: 'lax',
+        path: '/password/reset',
       })
       return res
     }


### PR DESCRIPTION
### Summary

<!-- Briefly describe the purpose of the pull request and the changes it introduces -->
Currently, the `resetPasswordToken` cookie is being sent with requests to endpoints other than `/password/reset`.
To enhance security, the `resetPasswordToken` cookie will only be sent to the `/password/reset` endpoint.

### Changes

<!-- Explain the specific changes or additions made -->
- Add the `path` attribute to the `resetPasswordToken` cookie (bceeaca9d0e5d9bc1486cf08eeef150b89ccc0ed)
  This change ensures that the `resetPasswordToken` cookie is not sent to endpoints other than `/password/reset`.

- Remove the code that deletes the `resetPasswordToken` cookie from `changePassword` (71245d34c3c3f40fc7009c3e59777e2679b01242)
  This is removed as it is no longer necessary.

### Testing

<!-- Describe how the changes were tested to ensure they work as expected -->
- Confirmed that navigating to `/password/reset` from the password reset email displays correctly.

- Added `console.log(req.nextUrl.pathname, req.cookies.get('resetPasswordToken'))` to `middleware.ts` and confirmed that the `resetPasswordToken` cookie is not sent to endpoints other than `/password/reset` as shown below.

```text
/ undefined
/account undefined
/login undefined
/password/account undefined
/password/change undefined
/password/forgot undefined
/password/reset { name: 'resetPasswordToken', value: 'SQz4foy_Rme-v2fkjJ4e' }
/sign-up undefined
/tasks undefined
/templates undefined
/users undefined
```

### Related Issues (Optional)

<!-- Mention any related issue numbers (excluding task management issue) -->
None

### Notes (Optional)

<!-- Include any additional information or considerations -->
None
