### PR TITLE
chore: add an icon to the label of the SNS authentication button

### DIFF
--- a/src/components/social-login-forms/index.tsx
+++ b/src/components/social-login-forms/index.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/solid'
 import { useSocialLoginForms } from './use-social-login-forms'
 import { Button } from '../buttons/button'
 
@@ -38,6 +39,9 @@ export function SocialLoginForms({ fromUrl }: Props) {
             onClick={handleClick}
           >
             {`${form.appName}で${authActionText}`}
+            <span className="ml-2">
+              <ArrowTopRightOnSquareIcon className="size-5 stroke-current" />
+            </span>
           </Button>
         </form>
       ))}


### PR DESCRIPTION
### Summary

<!-- Briefly describe the purpose of the pull request and the changes it introduces -->
Clicking the SNS authentication button opens a new tab.
To clarify this, an icon has been added to the SNS authentication button label.

### Changes

<!-- Explain the specific changes or additions made -->
- An icon has been added to the SNS authentication button.
<img width="1433" alt="スクリーンショット 2024-12-20 15 24 08" src="https://github.com/user-attachments/assets/56068f55-a517-4176-92bd-d1249010ea02" />
<img width="1433" alt="スクリーンショット 2024-12-20 14 51 38" src="https://github.com/user-attachments/assets/f31714d8-6d48-45f5-8403-a3d01eb7fa74" />

### Testing

<!-- Describe how the changes were tested to ensure they work as expected -->
- Verified that an icon is displayed on the SNS authentication button label, as shown in the attached image in Changes.

### Related Issues (Optional)

<!-- Mention any related issue numbers (excluding task management issue) -->
None

### Notes (Optional)

<!-- Include any additional information or considerations -->
None
