### PR TITLE
refactor: change the method of obtaining fromUrl in LoginForm

### DIFF
--- a/src/app/(auth)/login/_components/login-form/index.tsx
+++ b/src/app/(auth)/login/_components/login-form/index.tsx
@@ -11,10 +11,13 @@ import { useVisibilityToggle } from '@/components/visibility-toggle-icon/use-vis
 import { useLoginForm } from './use-login-form'
 import type { LabeledTextFields } from '@/types/labeled-text-fields'
 
-export function LoginForm() {
+type Props = {
+  fromUrl: string | undefined
+}
+export function LoginForm({ fromUrl }: Props) {
   const id = useId()
   const { register, handleSubmit, onSubmit, isSubmitting, errors } =
-    useLoginForm()
+    useLoginForm({ fromUrl })
   const { isVisible, toggleVisible } = useVisibilityToggle()
 
   const labeledTextFields: LabeledTextFields = [

--- a/src/app/(auth)/login/_components/login-form/use-login-form.tsx
+++ b/src/app/(auth)/login/_components/login-form/use-login-form.tsx
@@ -1,5 +1,4 @@
 import { zodResolver } from '@hookform/resolvers/zod'
-import { useSearchParams } from 'next/navigation'
 import { useCallback } from 'react'
 import { useForm } from 'react-hook-form'
 import { useErrorSnackbar } from '@/app/_components/snackbars/snackbar/use-error-snackbar'
@@ -9,10 +8,13 @@ import { login } from './login.api'
 import type { SubmitHandler } from 'react-hook-form'
 import type { z } from 'zod'
 
+type Params = {
+  fromUrl: string | undefined
+}
+
 type LoginFormValues = z.infer<typeof loginSchema>
 
-export function useLoginForm() {
-  const searchParams = useSearchParams()
+export function useLoginForm({ fromUrl }: Params) {
   const { openErrorSnackbar } = useErrorSnackbar()
   const {
     register,
@@ -31,13 +33,12 @@ export function useLoginForm() {
         openErrorSnackbar(result)
       } else {
         reset()
-        const fromUrl = searchParams.get('from_url')
-        let targetUrl = getPostLoginUrl(fromUrl)
+        const targetUrl = getPostLoginUrl(fromUrl)
         // Using router.push() causes the page displaying the modal to become Not Found.
         location.assign(targetUrl)
       }
     },
-    [openErrorSnackbar, reset, searchParams],
+    [openErrorSnackbar, reset, fromUrl],
   )
 
   return {

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -25,9 +25,7 @@ export default function Login({ searchParams }: Props) {
   return (
     <>
       <AuthHeading className="mb-7">ログイン</AuthHeading>
-      <Suspense>
-        <LoginForm />
-      </Suspense>
+      <LoginForm fromUrl={fromUrl} />
       <HorizontalRule className="my-8">または</HorizontalRule>
       <div className="space-y-8">
         <SocialLoginForms fromUrl={fromUrl} />

--- a/src/utils/url/get-post-login-url.ts
+++ b/src/utils/url/get-post-login-url.ts
@@ -1,6 +1,6 @@
 const origin = process.env.NEXT_PUBLIC_FRONTEND_ORIGIN
 
-export function getPostLoginUrl(fromUrl: string | null | undefined) {
+export function getPostLoginUrl(fromUrl: string | undefined) {
   let targetUrl = `${origin}/tasks`
 
   if (fromUrl && URL.canParse(fromUrl)) {


### PR DESCRIPTION
### Summary

<!-- Briefly describe the purpose of the pull request and the changes it introduces -->
In #418, the method of obtaining `formUrl` in `SocialLoginForms` has been changed to pass it as props from the `Page` component.
In line with this, also modify `LoginForm` to receive `fromUrl` as props.

### Changes

<!-- Explain the specific changes or additions made -->
- Changed the `Login` component to pass `fromUrl` as props to the `LoginForm` component.

### Testing

<!-- Describe how the changes were tested to ensure they work as expected -->
- Tested the following range in the [test case list](https://docs.google.com/spreadsheets/d/1ESeGIE8ghgZqR0U_RbAJMcV6XgRBxjOQdq2xNooxRjo/edit?usp=sharing):
  - `c-17-2`

### Related Issues (Optional)

<!-- Mention any related issue numbers (excluding task management issue) -->
None

### Notes (Optional)

<!-- Include any additional information or considerations -->
None
