### PR TITLE
perf: change all searchParams in Page components to useSearchParams

### DIFF
--- a/src/app/(auth)/login/_components/login-form/index.tsx
+++ b/src/app/(auth)/login/_components/login-form/index.tsx
@@ -15,14 +15,8 @@ import type { ReadonlyURLSearchParams } from 'next/navigation'
 
 export function LoginForm() {
   const id = useId()
-  const {
-    searchParamsRef,
-    register,
-    handleSubmit,
-    onSubmit,
-    isSubmitting,
-    errors,
-  } = useLoginForm()
+  const { fromUrl, register, handleSubmit, onSubmit, isSubmitting, errors } =
+    useLoginForm()
   const { isVisible, toggleVisible } = useVisibilityToggle()
 
   const labeledTextFields: LabeledTextFields = [
@@ -54,7 +48,7 @@ export function LoginForm() {
   ]
 
   const handleParamsReceived = (searchParams: ReadonlyURLSearchParams) => {
-    searchParamsRef.current = searchParams
+    fromUrl.current = searchParams.get('from_url')
   }
 
   return (

--- a/src/app/(auth)/login/_components/login-form/index.tsx
+++ b/src/app/(auth)/login/_components/login-form/index.tsx
@@ -6,18 +6,22 @@ import { Button } from '@/components/buttons/button'
 import { IconButton } from '@/components/buttons/icon-button'
 import { Label } from '@/components/form-controls/label'
 import { TextField } from '@/components/form-controls/text-field'
+import { SearchParamsLoader } from '@/components/search-params-loader'
 import { VisibilityToggleIcon } from '@/components/visibility-toggle-icon'
 import { useVisibilityToggle } from '@/components/visibility-toggle-icon/use-visibility-toggle'
 import { useLoginForm } from './use-login-form'
 import type { LabeledTextFields } from '@/types/labeled-text-fields'
 
-type Props = {
-  fromUrl: string | undefined
-}
-export function LoginForm({ fromUrl }: Props) {
+export function LoginForm() {
   const id = useId()
-  const { register, handleSubmit, onSubmit, isSubmitting, errors } =
-    useLoginForm({ fromUrl })
+  const {
+    searchParamsRef,
+    register,
+    handleSubmit,
+    onSubmit,
+    isSubmitting,
+    errors,
+  } = useLoginForm()
   const { isVisible, toggleVisible } = useVisibilityToggle()
 
   const labeledTextFields: LabeledTextFields = [
@@ -49,37 +53,40 @@ export function LoginForm({ fromUrl }: Props) {
   ]
 
   return (
-    <form noValidate={true} onSubmit={handleSubmit(onSubmit)}>
-      <div className="space-y-4">
-        {labeledTextFields.map((labeledTextField) => (
-          <div key={labeledTextField.id}>
-            <Label htmlFor={labeledTextField.id}>
-              {labeledTextField.label}
-            </Label>
-            <TextField
-              id={labeledTextField.id}
-              type={labeledTextField.type}
-              autoComplete={labeledTextField.autoComplete}
-              readOnly={isSubmitting}
-              register={labeledTextField.register}
-              errors={labeledTextField.errors}
-              suffixIcon={labeledTextField.suffixIcon}
-            />
-          </div>
-        ))}
-      </div>
-      <div className="mt-2 flex justify-end">
-        <Link href="/password/forgot" className="link">
-          パスワードを忘れた場合はこちら
-        </Link>
-      </div>
-      <Button
-        type="submit"
-        className="btn-primary mt-8"
-        status={isSubmitting ? 'pending' : 'idle'}
-      >
-        ログイン
-      </Button>
-    </form>
+    <>
+      <form noValidate={true} onSubmit={handleSubmit(onSubmit)}>
+        <div className="space-y-4">
+          {labeledTextFields.map((labeledTextField) => (
+            <div key={labeledTextField.id}>
+              <Label htmlFor={labeledTextField.id}>
+                {labeledTextField.label}
+              </Label>
+              <TextField
+                id={labeledTextField.id}
+                type={labeledTextField.type}
+                autoComplete={labeledTextField.autoComplete}
+                readOnly={isSubmitting}
+                register={labeledTextField.register}
+                errors={labeledTextField.errors}
+                suffixIcon={labeledTextField.suffixIcon}
+              />
+            </div>
+          ))}
+        </div>
+        <div className="mt-2 flex justify-end">
+          <Link href="/password/forgot" className="link">
+            パスワードを忘れた場合はこちら
+          </Link>
+        </div>
+        <Button
+          type="submit"
+          className="btn-primary mt-8"
+          status={isSubmitting ? 'pending' : 'idle'}
+        >
+          ログイン
+        </Button>
+      </form>
+      <SearchParamsLoader searchParamsRef={searchParamsRef} />
+    </>
   )
 }

--- a/src/app/(auth)/login/_components/login-form/index.tsx
+++ b/src/app/(auth)/login/_components/login-form/index.tsx
@@ -11,6 +11,7 @@ import { VisibilityToggleIcon } from '@/components/visibility-toggle-icon'
 import { useVisibilityToggle } from '@/components/visibility-toggle-icon/use-visibility-toggle'
 import { useLoginForm } from './use-login-form'
 import type { LabeledTextFields } from '@/types/labeled-text-fields'
+import type { ReadonlyURLSearchParams } from 'next/navigation'
 
 export function LoginForm() {
   const id = useId()
@@ -52,6 +53,10 @@ export function LoginForm() {
     },
   ]
 
+  const handleParamsReceived = (searchParams: ReadonlyURLSearchParams) => {
+    searchParamsRef.current = searchParams
+  }
+
   return (
     <>
       <form noValidate={true} onSubmit={handleSubmit(onSubmit)}>
@@ -86,7 +91,7 @@ export function LoginForm() {
           ログイン
         </Button>
       </form>
-      <SearchParamsLoader searchParamsRef={searchParamsRef} />
+      <SearchParamsLoader onParamsReceived={handleParamsReceived} />
     </>
   )
 }

--- a/src/app/(auth)/login/_components/login-form/use-login-form.tsx
+++ b/src/app/(auth)/login/_components/login-form/use-login-form.tsx
@@ -1,20 +1,18 @@
 import { zodResolver } from '@hookform/resolvers/zod'
-import { useCallback } from 'react'
+import { useCallback, useRef } from 'react'
 import { useForm } from 'react-hook-form'
 import { useErrorSnackbar } from '@/app/_components/snackbars/snackbar/use-error-snackbar'
 import { loginSchema } from '@/schemas/request/auth'
 import { getPostLoginUrl } from '@/utils/url/get-post-login-url'
 import { login } from './login.api'
+import type { ReadonlyURLSearchParams } from 'next/navigation'
 import type { SubmitHandler } from 'react-hook-form'
 import type { z } from 'zod'
 
-type Params = {
-  fromUrl: string | undefined
-}
-
 type LoginFormValues = z.infer<typeof loginSchema>
 
-export function useLoginForm({ fromUrl }: Params) {
+export function useLoginForm() {
+  const searchParamsRef = useRef<ReadonlyURLSearchParams>(null)
   const { openErrorSnackbar } = useErrorSnackbar()
   const {
     register,
@@ -33,15 +31,17 @@ export function useLoginForm({ fromUrl }: Params) {
         openErrorSnackbar(result)
       } else {
         reset()
+        const fromUrl = searchParamsRef.current?.get('from_url')
         const targetUrl = getPostLoginUrl(fromUrl)
         // Using router.push() causes the page displaying the modal to become Not Found.
         location.assign(targetUrl)
       }
     },
-    [openErrorSnackbar, reset, fromUrl],
+    [openErrorSnackbar, reset],
   )
 
   return {
+    searchParamsRef,
     register,
     handleSubmit,
     onSubmit,

--- a/src/app/(auth)/login/_components/login-form/use-login-form.tsx
+++ b/src/app/(auth)/login/_components/login-form/use-login-form.tsx
@@ -5,14 +5,13 @@ import { useErrorSnackbar } from '@/app/_components/snackbars/snackbar/use-error
 import { loginSchema } from '@/schemas/request/auth'
 import { getPostLoginUrl } from '@/utils/url/get-post-login-url'
 import { login } from './login.api'
-import type { ReadonlyURLSearchParams } from 'next/navigation'
 import type { SubmitHandler } from 'react-hook-form'
 import type { z } from 'zod'
 
 type LoginFormValues = z.infer<typeof loginSchema>
 
 export function useLoginForm() {
-  const searchParamsRef = useRef<ReadonlyURLSearchParams>(null)
+  const fromUrl = useRef<string>(null)
   const { openErrorSnackbar } = useErrorSnackbar()
   const {
     register,
@@ -31,8 +30,7 @@ export function useLoginForm() {
         openErrorSnackbar(result)
       } else {
         reset()
-        const fromUrl = searchParamsRef.current?.get('from_url')
-        const targetUrl = getPostLoginUrl(fromUrl)
+        const targetUrl = getPostLoginUrl(fromUrl.current)
         // Using router.push() causes the page displaying the modal to become Not Found.
         location.assign(targetUrl)
       }
@@ -41,7 +39,7 @@ export function useLoginForm() {
   )
 
   return {
-    searchParamsRef,
+    fromUrl,
     register,
     handleSubmit,
     onSubmit,

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -5,30 +5,20 @@ import { HorizontalRule } from '@/components/horizontal-rule'
 import { SocialLoginForms } from '@/components/social-login-forms'
 import { LoginForm } from './_components/login-form'
 import { LoginQueryParamSnackbar } from './_components/login-query-param-snackbar'
-import type { PageSearchParams } from '@/types/page'
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
   title: 'ログイン',
 }
 
-type Props = {
-  searchParams: PageSearchParams
-}
-
-export default function Login({ searchParams }: Props) {
-  let fromUrl = searchParams.from_url
-  if (typeof fromUrl !== 'string') {
-    fromUrl = undefined
-  }
-
+export default function Login() {
   return (
     <>
       <AuthHeading className="mb-7">ログイン</AuthHeading>
-      <LoginForm fromUrl={fromUrl} />
+      <LoginForm />
       <HorizontalRule className="my-8">または</HorizontalRule>
       <div className="space-y-8">
-        <SocialLoginForms fromUrl={fromUrl} />
+        <SocialLoginForms />
       </div>
       <div className="mt-10 text-center">
         <Link href="/sign-up" className="link">

--- a/src/app/(auth)/password/forgot/_components/forgot-password-query-param-snackbar/index.tsx
+++ b/src/app/(auth)/password/forgot/_components/forgot-password-query-param-snackbar/index.tsx
@@ -1,26 +1,24 @@
 'use client'
 
+import { useSearchParams } from 'next/navigation'
 import { useEffect } from 'react'
 import { useSnackbarsStore } from '@/app/_components/snackbars/use-snackbars-store'
 import { useQueryParams } from '@/utils/query-param/use-query-params'
-import type { PageSearchParams } from '@/types/page'
 
-type Props = {
-  searchParams: PageSearchParams
-}
-
-export function ForgotPasswordQueryParamSnackbar({ searchParams }: Props) {
+export function ForgotPasswordQueryParamSnackbar() {
+  const searchParams = useSearchParams()
+  const error = searchParams.get('err')
   const openSnackbar = useSnackbarsStore((state) => state.openSnackbar)
   const { cleanupQueryParams } = useQueryParams()
 
   useEffect(() => {
-    if (searchParams !== undefined) {
-      if (searchParams.err === 'token_not_found') {
+    if (error !== null) {
+      if (error === 'token_not_found') {
         openSnackbar({
           severity: 'error',
           message: 'パスワード再設定用メールからお手続きください。',
         })
-      } else if (searchParams.err === 'invalid_token') {
+      } else if (error === 'invalid_token') {
         openSnackbar({
           severity: 'error',
           message:
@@ -29,7 +27,7 @@ export function ForgotPasswordQueryParamSnackbar({ searchParams }: Props) {
       }
       cleanupQueryParams(['err'])
     }
-  }, [openSnackbar, cleanupQueryParams, searchParams])
+  }, [searchParams, error, openSnackbar, cleanupQueryParams])
 
   return null
 }

--- a/src/app/(auth)/password/forgot/page.tsx
+++ b/src/app/(auth)/password/forgot/page.tsx
@@ -1,19 +1,15 @@
 import Link from 'next/link'
+import { Suspense } from 'react'
 import { AuthHeading } from '@/components/headings/auth-heading'
 import { ForgotPasswordQueryParamSnackbar } from './_components/forgot-password-query-param-snackbar'
 import { RequestResetPasswordEmailForm } from './_components/request-reset-password-email-form'
-import type { PageSearchParams } from '@/types/page'
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
   title: 'パスワードリセット',
 }
 
-type Props = {
-  searchParams: PageSearchParams
-}
-
-export default function ForgotPassword({ searchParams }: Props) {
+export default function ForgotPassword() {
   return (
     <>
       <AuthHeading className="mb-8">パスワードリセット</AuthHeading>
@@ -23,7 +19,9 @@ export default function ForgotPassword({ searchParams }: Props) {
           ログイン画面へ
         </Link>
       </div>
-      <ForgotPasswordQueryParamSnackbar searchParams={searchParams} />
+      <Suspense>
+        <ForgotPasswordQueryParamSnackbar />
+      </Suspense>
     </>
   )
 }

--- a/src/components/search-params-loader/index.tsx
+++ b/src/components/search-params-loader/index.tsx
@@ -5,7 +5,7 @@ import { Suspense, useEffect } from 'react'
 import type { ReadonlyURLSearchParams } from 'next/navigation'
 
 type Props = {
-  searchParamsRef: React.RefObject<ReadonlyURLSearchParams | null>
+  onParamsReceived: (searchParams: ReadonlyURLSearchParams) => void
 }
 
 export function SearchParamsLoader(props: Props) {
@@ -16,12 +16,12 @@ export function SearchParamsLoader(props: Props) {
   )
 }
 
-function SearchParamsLoaderInner({ searchParamsRef }: Props) {
+function SearchParamsLoaderInner({ onParamsReceived }: Props) {
   const searchParams = useSearchParams()
 
   useEffect(() => {
-    searchParamsRef.current = searchParams
-  }, [searchParams, searchParamsRef])
+    onParamsReceived(searchParams)
+  }, [onParamsReceived, searchParams])
 
   return null
 }

--- a/src/components/search-params-loader/index.tsx
+++ b/src/components/search-params-loader/index.tsx
@@ -1,0 +1,27 @@
+// See https://is.gd/4CpzNm
+
+import { useSearchParams } from 'next/navigation'
+import { Suspense, useEffect } from 'react'
+import type { ReadonlyURLSearchParams } from 'next/navigation'
+
+type Props = {
+  searchParamsRef: React.RefObject<ReadonlyURLSearchParams | null>
+}
+
+export function SearchParamsLoader(props: Props) {
+  return (
+    <Suspense>
+      <SearchParamsLoaderInner {...props} />
+    </Suspense>
+  )
+}
+
+function SearchParamsLoaderInner({ searchParamsRef }: Props) {
+  const searchParams = useSearchParams()
+
+  useEffect(() => {
+    searchParamsRef.current = searchParams
+  }, [searchParams, searchParamsRef])
+
+  return null
+}

--- a/src/components/social-login-forms/index.tsx
+++ b/src/components/social-login-forms/index.tsx
@@ -17,16 +17,11 @@ const socialLoginForms = [
 const apiBaseUrl = `${process.env.NEXT_PUBLIC_API_ORIGIN}/api/v1/auth`
 
 export function SocialLoginForms() {
-  const {
-    searchParamsRef,
-    activeProvider,
-    authActionText,
-    handleClick,
-    windowName,
-  } = useSocialLoginForms()
+  const { fromUrl, activeProvider, authActionText, handleClick, windowName } =
+    useSocialLoginForms()
 
   const handleParamsReceived = (searchParams: ReadonlyURLSearchParams) => {
-    searchParamsRef.current = searchParams
+    fromUrl.current = searchParams.get('from_url')
   }
 
   return (

--- a/src/components/social-login-forms/index.tsx
+++ b/src/components/social-login-forms/index.tsx
@@ -3,6 +3,7 @@
 import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/solid'
 import { useSocialLoginForms } from './use-social-login-forms'
 import { Button } from '../buttons/button'
+import { SearchParamsLoader } from '../search-params-loader'
 
 const socialLoginForms = [
   {
@@ -14,13 +15,14 @@ const socialLoginForms = [
 ]
 const apiBaseUrl = `${process.env.NEXT_PUBLIC_API_ORIGIN}/api/v1/auth`
 
-type Props = {
-  fromUrl?: string
-}
-
-export function SocialLoginForms({ fromUrl }: Props) {
-  const { activeProvider, authActionText, handleClick, windowName } =
-    useSocialLoginForms({ fromUrl })
+export function SocialLoginForms() {
+  const {
+    searchParamsRef,
+    activeProvider,
+    authActionText,
+    handleClick,
+    windowName,
+  } = useSocialLoginForms()
 
   return (
     <>
@@ -45,6 +47,7 @@ export function SocialLoginForms({ fromUrl }: Props) {
           </Button>
         </form>
       ))}
+      <SearchParamsLoader searchParamsRef={searchParamsRef} />
     </>
   )
 }

--- a/src/components/social-login-forms/index.tsx
+++ b/src/components/social-login-forms/index.tsx
@@ -4,6 +4,7 @@ import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/solid'
 import { useSocialLoginForms } from './use-social-login-forms'
 import { Button } from '../buttons/button'
 import { SearchParamsLoader } from '../search-params-loader'
+import type { ReadonlyURLSearchParams } from 'next/navigation'
 
 const socialLoginForms = [
   {
@@ -23,6 +24,10 @@ export function SocialLoginForms() {
     handleClick,
     windowName,
   } = useSocialLoginForms()
+
+  const handleParamsReceived = (searchParams: ReadonlyURLSearchParams) => {
+    searchParamsRef.current = searchParams
+  }
 
   return (
     <>
@@ -47,7 +52,7 @@ export function SocialLoginForms() {
           </Button>
         </form>
       ))}
-      <SearchParamsLoader searchParamsRef={searchParamsRef} />
+      <SearchParamsLoader onParamsReceived={handleParamsReceived} />
     </>
   )
 }

--- a/src/types/page.ts
+++ b/src/types/page.ts
@@ -1,3 +1,0 @@
-export type PageSearchParams = {
-  [key: string]: string | string[] | undefined
-}

--- a/src/utils/url/get-post-login-url.ts
+++ b/src/utils/url/get-post-login-url.ts
@@ -1,6 +1,6 @@
 const origin = process.env.NEXT_PUBLIC_FRONTEND_ORIGIN
 
-export function getPostLoginUrl(fromUrl: string | null | undefined) {
+export function getPostLoginUrl(fromUrl: string | null) {
   let targetUrl = `${origin}/tasks`
 
   if (fromUrl && URL.canParse(fromUrl)) {

--- a/src/utils/url/get-post-login-url.ts
+++ b/src/utils/url/get-post-login-url.ts
@@ -1,6 +1,6 @@
 const origin = process.env.NEXT_PUBLIC_FRONTEND_ORIGIN
 
-export function getPostLoginUrl(fromUrl: string | undefined) {
+export function getPostLoginUrl(fromUrl: string | null | undefined) {
   let targetUrl = `${origin}/tasks`
 
   if (fromUrl && URL.canParse(fromUrl)) {


### PR DESCRIPTION
### Summary

<!-- Briefly describe the purpose of the pull request and the changes it introduces -->
I have replaced some `useSearchParams` with the `searchParams` of the Page component, but using the `searchParams` of the Page component causes the entire page to render dynamically. ([Reference page](https://nextjs.org/docs/14/app/api-reference/file-conventions/page))
Therefore, I have reverted the `searchParams` of the Page component back to `useSearchParams`.

### Changes

<!-- Explain the specific changes or additions made -->
- Added `SearchParamsLoader` component
- Replaced `searchParams` with `useSearchParams` on `Login`
- Replaced `searchParams` with `useSearchParams` on `ForgotPassword`

### Testing

<!-- Describe how the changes were tested to ensure they work as expected -->
Tested the following range in the [test case list](https://docs.google.com/spreadsheets/d/1ESeGIE8ghgZqR0U_RbAJMcV6XgRBxjOQdq2xNooxRjo/edit?usp=sharing)
  -  `c-17-1`, `c-17-2`
  - `d-7-1`
  - `e-13-1`

### Related Issues (Optional)

<!-- Mention any related issue numbers (excluding task management issue) -->
None

### Notes (Optional)

<!-- Include any additional information or considerations -->
None
