### PR TITLE
fix: fix the issue where the error snackbar does not display when redirected to /login

### DIFF
--- a/src/utils/login-path/generate-redirect-login-path.server.ts
+++ b/src/utils/login-path/generate-redirect-login-path.server.ts
@@ -7,5 +7,5 @@ export function generateRedirectLoginPath() {
   const params = headers().get('Tascon-Params') ?? ''
 
   const fromUrl = generateFromUrlParam(pathname, params)
-  return `/login?${fromUrl}?err='unauthorized'`
+  return `/login?${fromUrl}&err=unauthorized`
 }

--- a/src/utils/login-path/use-redirect-login-path.tsx
+++ b/src/utils/login-path/use-redirect-login-path.tsx
@@ -9,5 +9,5 @@ export function useRedirectLoginPath({ searchParams }: Params) {
   const params = searchParams?.toString() ?? null
 
   const fromUrl = generateFromUrlParam(pathname, params)
-  return `/login?${fromUrl}&err='unauthorized'`
+  return `/login?${fromUrl}&err=unauthorized`
 }


### PR DESCRIPTION
### Summary

Currently, there are instances where the error snackbar does not display when redirected to the login page due to unauthentication, as shown in the image below. 

![画面収録 2024-12-25 18 56 42](https://github.com/user-attachments/assets/0a98be50-80cf-41f7-8233-12abe6b6a6ef)

![画面収録 2024-12-25 19 04 19](https://github.com/user-attachments/assets/c3a10f14-9b32-441e-85ae-5e3a42403c7c)

To address this issue, I have modified the logic for generating the redirect URL to ensure the error snackbar is displayed appropriately.

### Changes

- Updated the redirect URL generation logic to ensure the error snackbar is shown when redirected to the /login page.

### Testing

As demonstrated in the GIF image below, I have confirmed that the error snackbar is displayed correctly.

![画面収録 2024-12-25 19 07 44](https://github.com/user-attachments/assets/5048403f-7426-4c36-971e-64a8aaf837d6)

![画面収録 2024-12-25 19 10 46](https://github.com/user-attachments/assets/77b271c2-ea89-4750-b066-47845bc04456)

### Related Issues (Optional)

None

### Notes (Optional)

None