### PR TITLE
fix: fix the issue where query parameters are removed from from_url

### DIFF
--- a/src/components/pages/account-page/logout-button/index.tsx
+++ b/src/components/pages/account-page/logout-button/index.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { ReadonlyURLSearchParams, useRouter } from 'next/navigation'
-import { useId, useRef, useState } from 'react'
+import { useId, useState } from 'react'
 import { useErrorSnackbar } from '@/app/_components/snackbars/snackbar/use-error-snackbar'
 import { Button } from '@/components/buttons/button'
 import { SearchParamsLoader } from '@/components/search-params-loader'
@@ -9,11 +9,10 @@ import { useRedirectLoginPath } from '@/utils/login-path/use-redirect-login-path
 import { logout } from './logout.api'
 
 export function LogoutButton() {
-  const searchParams = useRef<ReadonlyURLSearchParams>(null)
+  const [searchParams, setSearchParams] =
+    useState<ReadonlyURLSearchParams | null>(null)
   const [isLoggingOut, setIsLoggingOut] = useState(false)
-  const redirectLoginPath = useRedirectLoginPath({
-    searchParams: searchParams.current,
-  })
+  const redirectLoginPath = useRedirectLoginPath({ searchParams })
   const id = useId()
   const router = useRouter()
   const { openErrorSnackbar } = useErrorSnackbar()
@@ -34,10 +33,6 @@ export function LogoutButton() {
     setIsLoggingOut(false)
   }
 
-  const handleParamsReceived = (params: ReadonlyURLSearchParams) => {
-    searchParams.current = params
-  }
-
   return (
     // 'id' is used to manage popstate events in AccountModal.
     <>
@@ -50,7 +45,7 @@ export function LogoutButton() {
       >
         ログアウト
       </Button>
-      <SearchParamsLoader onParamsReceived={handleParamsReceived} />
+      <SearchParamsLoader onParamsReceived={setSearchParams} />
     </>
   )
 }


### PR DESCRIPTION
### Summary

This pull request addresses an issue where query parameters were being removed from the `from_url` function. 
With this PR applied, the query parameters of `from_url` will be retained even when the value of the `bearerToken` cookie is invalid during logout.

### Changes

- Changed the `searchParams` in `LogoutButton` to use state.

### Testing

I have confirmed that the query parameters of `from_url` are retained, as shown in the GIF image below.

![画面収録 2024-12-26 9 21 41](https://github.com/user-attachments/assets/cbfd6400-97d0-47f9-8394-ed027645198b)

### Related Issues (Optional)

Close: #440

### Notes (Optional)

None