### PR TITLE
refactor: remove resetPasswordToken prop from ResetPasswordForm

### DIFF
--- a/src/app/(auth)/password/reset/_components/reset-password-form/index.tsx
+++ b/src/app/(auth)/password/reset/_components/reset-password-form/index.tsx
@@ -20,11 +20,7 @@ import type { z } from 'zod'
 
 type ResetPasswordFormValues = z.infer<typeof resetPasswordSchema>
 
-type Props = {
-  resetPasswordToken: string
-}
-
-export function ResetPasswordForm({ resetPasswordToken }: Props) {
+export function ResetPasswordForm() {
   const id = useId()
   const { isVisible, toggleVisible } = useVisibilityToggle()
   const router = useRouter()
@@ -48,7 +44,7 @@ export function ResetPasswordForm({ resetPasswordToken }: Props) {
   }
 
   const onSubmit: SubmitHandler<ResetPasswordFormValues> = async (data) => {
-    const result = await resetPassword({ resetPasswordToken, ...data })
+    const result = await resetPassword(data)
     if (result.status === 'error') {
       if (result.name === 'HttpError') {
         handleHttpError(result)

--- a/src/app/(auth)/password/reset/_components/reset-password-form/reset-password.api.ts
+++ b/src/app/(auth)/password/reset/_components/reset-password-form/reset-password.api.ts
@@ -14,7 +14,6 @@ import { validateData } from '@/utils/validation/validate-data'
 import type { CamelCaseKeys } from 'camelcase-keys'
 
 type Params = {
-  resetPasswordToken: string | null
   password: string
 }
 
@@ -26,10 +25,7 @@ const dataSchema = z.object({
 
 type Data = CamelCaseKeys<z.infer<typeof dataSchema>, true>
 
-export async function resetPassword({
-  resetPasswordToken,
-  ...bodyData
-}: Params) {
+export async function resetPassword(bodyData: Params) {
   const fetchDataResult = await fetchData(
     `${process.env.API_ORIGIN}/api/v1/auth/password`,
     {
@@ -41,7 +37,7 @@ export async function resetPassword({
       body: JSON.stringify({
         ...snakecaseKeys(bodyData, { deep: false }),
         password_confirmation: bodyData.password,
-        reset_password_token: resetPasswordToken,
+        reset_password_token: cookies().get('resetPasswordToken')?.value,
       }),
     },
   )

--- a/src/app/(auth)/password/reset/page.tsx
+++ b/src/app/(auth)/password/reset/page.tsx
@@ -1,5 +1,3 @@
-import { cookies } from 'next/headers'
-import { redirect } from 'next/navigation'
 import { AuthHeading } from '@/components/headings/auth-heading'
 import { ResetPasswordForm } from './_components/reset-password-form'
 import type { Metadata } from 'next'
@@ -9,17 +7,11 @@ export const metadata: Metadata = {
 }
 
 export default function ResetPassword() {
-  const cookieStore = cookies()
-  const resetPasswordToken = cookieStore.get('resetPasswordToken')?.value
-  if (resetPasswordToken === undefined) {
-    redirect('/password/forgot?err=token_not_found')
-  }
-
   return (
     <>
       <AuthHeading className="mb-8">新規パスワード設定</AuthHeading>
       <div className="mx-2">
-        <ResetPasswordForm resetPasswordToken={resetPasswordToken} />
+        <ResetPasswordForm />
       </div>
     </>
   )

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -43,6 +43,13 @@ export async function middleware(req: NextRequest) {
       })
       return res
     }
+
+    const hasResetPasswordTokenCookie = req.cookies.has('resetPasswordToken')
+    if (!hasResetPasswordTokenCookie) {
+      const forgotUrl = new URL('/password/forgot', req.url)
+      forgotUrl.searchParams.set('err', 'token_not_found')
+      return NextResponse.redirect(forgotUrl)
+    }
   }
 
   // Add the pathname and query parameters to the request headers.


### PR DESCRIPTION
### Summary

This pull request refactors the `ResetPasswordForm` component by removing the `resetPasswordToken` prop. The changes aim to simplify the component's structure and improve the handling of the reset password process.

### Changes

- Removed the `resetPasswordToken` prop from the `ResetPasswordForm` component.
- Updated the reset password API function to directly use the token from cookies instead of passing it as a prop.
- Modified the redirection logic to handle cases where the `resetPasswordToken` cookie does not exist, moving this logic to middleware.

### Testing

Tested the following range in the [test case list](https://docs.google.com/spreadsheets/d/1ESeGIE8ghgZqR0U_RbAJMcV6XgRBxjOQdq2xNooxRjo/edit?usp=sharing):
- `e-2-1`
- `e-13-1`, `e-13-2`

### Related Issues (Optional)

None

### Notes (Optional)

None