### PR TITLE
refactor: remove resetPasswordToken checks from middleware

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -16,11 +16,7 @@ export async function middleware(req: NextRequest) {
   // Redirect to the login page if the user is not authenticated.
   if (protectedPaths.some((path) => nextUrl.pathname.startsWith(path))) {
     const hasBearerTokenCookie = req.cookies.has('bearerToken')
-    const hasResetPasswordToken =
-      nextUrl.searchParams.has('reset_password_token') ||
-      req.cookies.has('resetPasswordToken')
-
-    if (!hasBearerTokenCookie && !hasResetPasswordToken) {
+    if (!hasBearerTokenCookie) {
       const loginUrl = new URL('/login', req.url)
       const fromUrl = `${origin}${nextUrl.pathname}${nextUrl.search}`
       loginUrl.searchParams.set('from_url', fromUrl)


### PR DESCRIPTION
### Summary

This pull request aims to simplify the middleware by removing the checks for the `resetPasswordToken`. This change streamlines the authentication process and reduces unnecessary complexity in the middleware logic.

### Changes

- Removed the `resetPasswordToken` validation checks from the middleware.

### Testing

I confirmed that it is possible to navigate to `/password/reset` even when not logged in, provided that the `resetPasswordToken` cookie is set. The steps to verify this are as follows:
1. Obtain the `resetPasswordToken`.
2. Ensure that the `resetPasswordToken` cookie is set and the `bearerToken` cookie is not set.
3. Navigate to `/password/reset`.

### Related Issues (Optional)

None

### Notes (Optional)

None