### PR TITLE
refactor: simplify error handling in reset password form

### DIFF
--- a/src/app/(auth)/password/reset/_components/reset-password-form/index.tsx
+++ b/src/app/(auth)/password/reset/_components/reset-password-form/index.tsx
@@ -12,8 +12,6 @@ import { TextField } from '@/components/form-controls/text-field'
 import { VisibilityToggleIcon } from '@/components/visibility-toggle-icon'
 import { useVisibilityToggle } from '@/components/visibility-toggle-icon/use-visibility-toggle'
 import { resetPasswordSchema } from '@/schemas/request/auth'
-import { ErrorObject } from '@/types/error'
-import { HttpError } from '@/utils/error/custom/http-error'
 import { resetPassword } from './reset-password.api'
 import type { SubmitHandler } from 'react-hook-form'
 import type { z } from 'zod'
@@ -35,19 +33,11 @@ export function ResetPasswordForm() {
     resolver: zodResolver(resetPasswordSchema),
   })
 
-  const handleHttpError = (err: ErrorObject<HttpError>) => {
-    if (err.statusCode === 401) {
-      router.push('/password/forgot?err=invalid_token')
-    } else {
-      openErrorSnackbar(err)
-    }
-  }
-
   const onSubmit: SubmitHandler<ResetPasswordFormValues> = async (data) => {
     const result = await resetPassword(data)
     if (result.status === 'error') {
-      if (result.name === 'HttpError') {
-        handleHttpError(result)
+      if (result.name === 'HttpError' && result.statusCode === 401) {
+        router.push('/password/forgot?err=invalid_token')
       } else {
         openErrorSnackbar(result)
       }


### PR DESCRIPTION
### Summary

This pull request aims to simplify the error handling in the reset password form, enhancing code clarity and maintainability.

### Changes

- Removed the redundant error handling function that was previously used.
- Directly handled 401 errors within the submit handler, streamlining the error management process.

### Testing

Tested the following range in the [test case list](https://docs.google.com/spreadsheets/d/1ESeGIE8ghgZqR0U_RbAJMcV6XgRBxjOQdq2xNooxRjo/edit?usp=sharing):
- `e-13-1`

### Related Issues (Optional)

None

### Notes (Optional)

None