### PR TITLE
fix: update disabled button cursor style

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -159,7 +159,7 @@ module.exports = {
             {},
         },
         '.btn-outline-disabled': {
-          '@apply cursor-wait border-2 border-gray-400 text-gray-400': {},
+          '@apply cursor-not-allowed border-2 border-gray-400 text-gray-400': {},
         },
         '.btn-outline-danger': {
           '@apply btn-shadow border-2 border-red-600 bg-white text-red-600 disabled:btn-outline-disabled disabled:duration-0':


### PR DESCRIPTION
### Summary

Currently, when the outline button is disabled, the cursor changes to a wait state. 

![画面収録 2024-12-26 14 24 24](https://github.com/user-attachments/assets/d3236743-5a04-4900-b5fe-a990aee63dc3)

While it is appropriate to indicate a wait during processing, it feels inconsistent when the button's disabled attribute is set to true. Therefore, this update ensures that whenever the button is disabled, the cursor will change to a not-allowed state, regardless of the underlying cause.

### Changes

- Changed the cursor style from `cursor-wait` to `cursor-not-allowed` for the `btn-outline-disabled` class.

### Testing

I have confirmed that the not-allowed cursor is displayed as shown in the attached GIF.

![画面収録 2024-12-26 14 27 34](https://github.com/user-attachments/assets/bd8b0260-3975-4e03-ad71-71eb5fd7748f)


### Related Issues (Optional)

None

### Notes (Optional)

None