### PR TITLE
refactor: modify EditableText to make the last button unselectable only on hover

### DIFF
--- a/src/components/editable-text/index.tsx
+++ b/src/components/editable-text/index.tsx
@@ -90,7 +90,7 @@ export function EditableText({
       ) : (
         <div
           ref={contentRef}
-          className={`relative h-fit has-[>button:hover]:select-none ${
+          className={`relative h-fit has-[>button:last-of-type:hover]:select-none ${
             isDraggingInside ? 'hover:cursor-text' : 'hover:cursor-default'
           }`}
           onMouseEnter={handleMouseEnter}


### PR DESCRIPTION
### Summary

When a `button` element is passed as `children` to `EditableText`, unintended behavior may occur. Modify `EditableText` so that the `select-none` class is applied only when hovering over the edit button within `EditableText`.

### Changes

- [`src/components/editable-text/index.tsx`](diffhunk://#diff-a5ab818381a23a8b30b9c95ce376288a0cea1f529cf1030002cac2d412de8b42L93-R93): Changed the CSS class from `has-[>button:hover]:select-none` to `has-[>button:last-of-type:hover]:select-none` to target only the last button's hover state.

### Testing

Verified that the `select-none` class is applied only when hovering over the edit button within `EditableText`, as shown in the following GIF.

- Add a `button` element and confirm that the entire content may be selected for a moment
![画面収録 2024-12-26 19 26 08](https://github.com/user-attachments/assets/e29366d8-0eef-4298-86d4-32f38ef02328)

- Remove the added `button` element and verify that it operates normally
![画面収録 2024-12-26 19 27 29](https://github.com/user-attachments/assets/fd5b29f8-7b87-4135-b4e4-4345f75ecb24)

### Related Issues (Optional)

None

### Notes (Optional)

None