### PR TITLE
chore: change dependabot update schedule to daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: 'docker'
     directory: '/'
     schedule:
-      interval: 'monthly'
+      interval: 'daily'
       time: '03:00'
       timezone: 'Asia/Tokyo'
     reviewers:
@@ -17,7 +17,7 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'monthly'
+      interval: 'daily'
       time: '03:00'
       timezone: 'Asia/Tokyo'
     reviewers:


### PR DESCRIPTION
### Summary

This pull request updates the schedule for Dependabot to check for updates daily instead of monthly. This change aims to ensure that our dependencies are kept up-to-date more frequently, enhancing the security and stability of the project.

### Changes

- Modified the Dependabot configuration to set the update schedule to daily for both Docker and npm packages.

### Testing

The changes were tested by reviewing the updated configuration file to ensure that the schedule is correctly set to daily. 

### Related Issues (Optional)

None

### Notes (Optional)

None