### PR TITLE
chore: update dependabot to update Node to v22

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
     target-branch: 'main'
     ignore:
       - dependency-name: 'node'
-        versions: ['>=21.0']
+        versions: ['>=23.0']
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:


### PR DESCRIPTION
### Summary

This pull request updates the Dependabot configuration to ensure that the Node.js version is set to v22. This change is intended to keep Node.js on LTS.

### Changes

- Adjusted the settings to ignore any Node.js versions greater than or equal to 23.0.

### Testing

Verified that we have adjusted our settings to ignore Node.js versions above 23.0.

### Related Issues (Optional)

None

### Notes (Optional)

None