### PR TITLE
feat: add image placeholder for loading state

### DIFF
--- a/src/components/avatars/avatar/index.tsx
+++ b/src/components/avatars/avatar/index.tsx
@@ -1,5 +1,6 @@
 import DefaultAvatar from 'boring-avatars'
 import Image from 'next/image'
+import { getImagePlaceholderUrl } from '@/utils/image-placeholder/get-image-placeholder-url'
 
 type Props = {
   size: number
@@ -28,6 +29,7 @@ export function Avatar({ size, name, avatarUrl, priority = false }: Props) {
       width={size}
       className={`aspect-square bg-white object-cover ${shapeClasses}`}
       priority={priority}
+      placeholder={getImagePlaceholderUrl(size, size)}
     />
   )
 }

--- a/src/utils/image-placeholder/get-image-placeholder-url.ts
+++ b/src/utils/image-placeholder/get-image-placeholder-url.ts
@@ -1,0 +1,30 @@
+function skeleton(width: number, height: number) {
+  return `
+    <svg width="${width}" height="${height}" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <defs>
+        <linearGradient id="g">
+          <stop stop-color="#d1d5db" offset="20%" />
+          <stop stop-color="#f3f4f6" offset="50%" />
+          <stop stop-color="#d1d5db" offset="70%" />
+        </linearGradient>
+      </defs>
+      <rect width="${width}" height="${height}" fill="#d1d5db" />
+      <rect id="r" width="${width}" height="${height}" fill="url(#g)" />
+      <animate xlink:href="#r" attributeName="x" from="-${width}" to="${width}" dur="1s" repeatCount="indefinite" />
+    </svg>`
+}
+
+function toBase64(str: string) {
+  if (typeof window === 'undefined') {
+    return Buffer.from(str).toString('base64')
+  } else {
+    return window.btoa(str)
+  }
+}
+
+export function getImagePlaceholderUrl(
+  width: number,
+  height: number,
+): `data:image/${string}` {
+  return `data:image/svg+xml;base64,${toBase64(skeleton(width, height))}`
+}


### PR DESCRIPTION
### Summary

This pull request introduces an image placeholder for the loading state of the Avatar component, enhancing the user experience during image loading.

### Changes

- Implemented a placeholder for the Avatar component to provide feedback while images are fetched.
- Introduced a utility function that generates a base64-encoded SVG placeholder.
- Applied the SVG placeholder to the Image component to ensure a seamless loading experience.

### Testing

Verified that placeholders are displayed during avatar loading, as shown below.

![画面収録 2025-01-18 19 11 28](https://github.com/user-attachments/assets/9f22cba1-b0fa-4062-85f6-f3c9255f79be)

### Related Issues (Optional)

N/A

### Notes (Optional)

N/A