### PR TITLE
refactor: rename 'details' in HttpError to 'data'

### DIFF
--- a/src/app/(auth)/sign-up/_components/sign-up-form/use-sign-up-form.tsx
+++ b/src/app/(auth)/sign-up/_components/sign-up-form/use-sign-up-form.tsx
@@ -44,9 +44,9 @@ export function useSignUpForm() {
 
   const handleHttpError = useCallback(
     (err: ErrorObject<HttpError>) => {
-      const { details } = err
-      if (isValidValue(formErrorsSchema, details)) {
-        handleFormErrors(details)
+      const { data } = err
+      if (isValidValue(formErrorsSchema, data)) {
+        handleFormErrors(data)
       } else {
         openErrorSnackbar(err)
       }

--- a/src/types/error.ts
+++ b/src/types/error.ts
@@ -21,5 +21,5 @@ export type ErrorBaseObject = Pick<Errors, 'message' | 'requestId'> & {
 }
 
 export type ErrorObject<T extends Errors> = T extends HttpError
-  ? Pick<T, 'name' | 'statusCode' | 'details'> & ErrorBaseObject
+  ? Pick<T, 'name' | 'statusCode' | 'data'> & ErrorBaseObject
   : Pick<T, 'name'> & ErrorBaseObject

--- a/src/utils/api/fetch-data.ts
+++ b/src/utils/api/fetch-data.ts
@@ -38,7 +38,7 @@ export async function fetchData(
     )
 
     if (!res.ok) {
-      throw new HttpError({ requestId, res, details: data })
+      throw new HttpError({ requestId, res, data })
     }
 
     return { headers: res.headers, data }

--- a/src/utils/error/create-error-object.ts
+++ b/src/utils/error/create-error-object.ts
@@ -15,7 +15,7 @@ export function createErrorObject(err: Errors) {
       ...errorBaseObject,
       name: err.name,
       statusCode: err.statusCode,
-      details: err.details,
+      data: err.data,
     }
   } else {
     errorObject = {

--- a/src/utils/error/custom/http-error.ts
+++ b/src/utils/error/custom/http-error.ts
@@ -1,20 +1,20 @@
 type Params = {
   requestId: string
   res: Response
-  details: unknown
+  data: unknown
 }
 
 export class HttpError extends Error {
   name: 'HttpError'
   requestId: Params['requestId']
   statusCode: Params['res']['status']
-  details: Params['details']
+  data: Params['data']
 
-  constructor({ requestId, res, details }: Params) {
+  constructor({ requestId, res, data }: Params) {
     super('リクエストの処理中にエラーが発生しました。')
     this.name = 'HttpError'
     this.requestId = requestId
     this.statusCode = res.status
-    this.details = details
+    this.data = data
   }
 }


### PR DESCRIPTION
### Summary

This pull request refactors the error handling structure by renaming the 'details' property in the `HttpError` class to 'data'. This change aims to enhance consistency across error objects and improve clarity in error reporting.

### Changes

- Renamed the 'details' property in the `HttpError` class to 'data'.
- Updated all relevant references in the codebase to reflect this change.

### Testing

Tested the following range in the [test case list](https://docs.google.com/spreadsheets/d/1ESeGIE8ghgZqR0U_RbAJMcV6XgRBxjOQdq2xNooxRjo/edit?usp=sharing):

- `b-2-1`, `b-13-1`

### Related Issues (Optional)

N/A

### Notes (Optional)

No additional information or considerations at this time.