### PR TITLE
fix: correct to display the proper error message in the snackbar on login failure

### DIFF
--- a/src/app/(auth)/login/_components/login-form/use-login-form.tsx
+++ b/src/app/(auth)/login/_components/login-form/use-login-form.tsx
@@ -1,14 +1,22 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useCallback, useRef } from 'react'
 import { useForm } from 'react-hook-form'
+import { z } from 'zod'
 import { useErrorSnackbar } from '@/app/_components/snackbars/snackbar/use-error-snackbar'
 import { loginSchema } from '@/schemas/request/auth'
+import { ErrorObject } from '@/types/error'
+import { HttpError } from '@/utils/error/custom/http-error'
+import { isValidValue } from '@/utils/type-guard/is-valid-data'
 import { getPostLoginUrl } from '@/utils/url/get-post-login-url'
 import { login } from './login.api'
 import type { SubmitHandler } from 'react-hook-form'
-import type { z } from 'zod'
 
 type LoginFormValues = z.infer<typeof loginSchema>
+
+const snackbarErrorsSchema = z.object({
+  success: z.literal(false),
+  errors: z.array(z.string()),
+})
 
 export function useLoginForm() {
   const fromUrl = useRef<string>(null)
@@ -23,11 +31,26 @@ export function useLoginForm() {
     resolver: zodResolver(loginSchema),
   })
 
+  const handleHttpError = useCallback(
+    (err: ErrorObject<HttpError>) => {
+      if (isValidValue(snackbarErrorsSchema, err.data)) {
+        openErrorSnackbar(err, err.data.errors[0])
+      } else {
+        openErrorSnackbar(err)
+      }
+    },
+    [openErrorSnackbar],
+  )
+
   const onSubmit: SubmitHandler<LoginFormValues> = useCallback(
     async (data) => {
       const result = await login(data)
       if (result.status === 'error') {
-        openErrorSnackbar(result)
+        if (result.name === 'HttpError') {
+          handleHttpError(result)
+        } else {
+          openErrorSnackbar(result)
+        }
       } else {
         reset()
         const targetUrl = getPostLoginUrl(fromUrl.current)
@@ -35,7 +58,7 @@ export function useLoginForm() {
         location.assign(targetUrl)
       }
     },
-    [openErrorSnackbar, reset],
+    [handleHttpError, openErrorSnackbar, reset],
   )
 
   return {

--- a/src/app/_components/snackbars/snackbar/use-error-snackbar.tsx
+++ b/src/app/_components/snackbars/snackbar/use-error-snackbar.tsx
@@ -22,15 +22,25 @@ export function useErrorSnackbar() {
   const openSnackbar = useSnackbarsStore((state) => state.openSnackbar)
 
   const openErrorSnackbar = useCallback(
-    (err: ErrorObject<Errors>) => {
+    (err: ErrorObject<Errors>, message?: string) => {
+      let snackbarContent: Omit<Parameters<typeof openSnackbar>[0], 'severity'>
+      if (isFatalError(err)) {
+        snackbarContent = {
+          message:
+            message ?? '予期せぬエラーが発生しました。問題を報告してください。',
+          actionButton: (
+            <ReportIssueLink info={`Request ID: ${err.requestId}`} />
+          ),
+        }
+      } else {
+        snackbarContent = {
+          message: message ?? err.message,
+        }
+      }
+
       openSnackbar({
+        ...snackbarContent,
         severity: 'error',
-        message: isFatalError(err)
-          ? '予期せぬエラーが発生しました。問題を報告してください。'
-          : err.message,
-        actionButton: isFatalError(err) ? (
-          <ReportIssueLink info={`Request ID: ${err.requestId}`} />
-        ) : undefined,
       })
     },
     [openSnackbar],


### PR DESCRIPTION
### Summary

Change `HttpError` so that the error message on login failure is "リクエストの処理中にエラーが発生しました。" The error message is no longer displayed other than “An error occurred during processing.
Make changes to `use-login-form.tsx` and `use-error-snackbar.tsx` so that the correct error message is displayed in the snackbar.

![before-after-7](https://github.com/user-attachments/assets/a19c0fdb-c874-4337-82d7-c01c60584c30)

![before-after-8](https://github.com/user-attachments/assets/a24a57f6-95f9-44bf-a9e0-6325d93c7686)

### Changes

- Modify `openErrorSnackbar` to accept a `message` argument and to display this in the snackbar if a `message` argument is received.
- Create `handleHttpError` in `use-login-form.tsx` to pass `message` argument to `openErrorSnackbar` if `HttpError` is raised and `snackbarErrorsSchema` condition is met.

### Testing

Tested the following range in the [test case list](https://docs.google.com/spreadsheets/d/1ESeGIE8ghgZqR0U_RbAJMcV6XgRBxjOQdq2xNooxRjo/ 

- `c-12-2`, `c-14-1`

### Related issues (optional)

N/A

### Notes (optional)

No additional information or considerations at this time.