### PR TITLE
fix: correct errors that occurs when navigating to the account page

### DIFF
--- a/src/components/pages/account-page/current-user-info/current-user-change-password-form-show-button/index.tsx
+++ b/src/components/pages/account-page/current-user-info/current-user-change-password-form-show-button/index.tsx
@@ -2,7 +2,7 @@ import { getCurrentUser } from '@/utils/api/server/get-current-user'
 import { ChangePasswordFormShowButton } from './change-password-form-show-button'
 
 export async function CurrentUserChangePasswordFormShowButton() {
-  const { data: currentUser } = await getCurrentUser()
+  const { account: currentUser } = await getCurrentUser()
 
   return (
     <ChangePasswordFormShowButton

--- a/src/components/pages/account-page/current-user-info/editable-avatar/avatar-editor/index.tsx
+++ b/src/components/pages/account-page/current-user-info/editable-avatar/avatar-editor/index.tsx
@@ -6,7 +6,7 @@ import { ValidationErrorMessage } from '@/components/form-controls/validation-er
 import { useAvatarEditor } from './use-avatar-editor'
 
 type Props = {
-  avatarUrl: string | null
+  avatarUrl?: string
   children: React.ReactElement
 }
 
@@ -41,7 +41,7 @@ export function AvatarEditor({ avatarUrl, children }: Props) {
         {avatarUrl && !isSubmitting && (
           <IconButton
             type="button"
-            className={`absolute right-0.5 top-0.5 z-10 duration-[1ms] hover:visible peer-hover:visible [@media(hover:hover)]:focus-visible:visible [@media(hover:hover)]:peer-focus-visible:visible ${
+            className={`absolute top-0.5 right-0.5 z-10 duration-[1ms] peer-hover:visible hover:visible [@media(hover:hover)]:peer-focus-visible:visible [@media(hover:hover)]:focus-visible:visible ${
               isDeletingAvatar ? '' : '[@media(hover:hover)]:invisible'
             }`}
             aria-label="アバター削除"

--- a/src/components/pages/account-page/current-user-info/editable-avatar/index.tsx
+++ b/src/components/pages/account-page/current-user-info/editable-avatar/index.tsx
@@ -5,7 +5,7 @@ import { AvatarEditor } from './avatar-editor'
 const size = 128
 
 export async function EditableAvatar() {
-  const { data: currentUser } = await getCurrentUser()
+  const { account: currentUser } = await getCurrentUser()
 
   return (
     <AvatarEditor avatarUrl={currentUser.avatarUrl}>

--- a/src/components/pages/account-page/current-user-info/editable-bio/bio-editor/index.tsx
+++ b/src/components/pages/account-page/current-user-info/editable-bio/bio-editor/index.tsx
@@ -28,7 +28,7 @@ type ChangeBioFormValue = z.infer<typeof bioSchema>
 
 type Props = Pick<React.ComponentProps<typeof EditableText>, 'children'> & {
   currentUserId: string
-  initialBio: string
+  initialBio: string | undefined
   label: React.ReactElement
   privacyTag: React.ReactElement
   unsavedChangeTag: React.ReactElement
@@ -36,7 +36,7 @@ type Props = Pick<React.ComponentProps<typeof EditableText>, 'children'> & {
 
 export function BioEditor({
   currentUserId,
-  initialBio,
+  initialBio = '',
   label,
   privacyTag,
   unsavedChangeTag,

--- a/src/components/pages/account-page/current-user-info/editable-bio/index.tsx
+++ b/src/components/pages/account-page/current-user-info/editable-bio/index.tsx
@@ -13,7 +13,7 @@ import { BioEditor } from './bio-editor'
 const height = 160
 
 export async function EditableBio() {
-  const { data: currentUser } = await getCurrentUser()
+  const { account: currentUser } = await getCurrentUser()
   const currentUserId = currentUser.id.toString()
 
   return (
@@ -27,7 +27,7 @@ export async function EditableBio() {
       {/* Pass 'key' so that the bio is re-rendered when it is re-validated */}
       <BioCollapsibleSection key={currentUser.bio} height={height}>
         <DetailItemContentLayout>
-          {currentUser.bio === '' ? (
+          {currentUser.bio === undefined ? (
             <p className="text-gray-500">自己紹介を登録してください...</p>
           ) : (
             <DetailMultiLineText>{currentUser.bio}</DetailMultiLineText>

--- a/src/components/pages/account-page/current-user-info/editable-email/index.tsx
+++ b/src/components/pages/account-page/current-user-info/editable-email/index.tsx
@@ -10,7 +10,7 @@ import { getCurrentUser } from '@/utils/api/server/get-current-user'
 import { EmailEditor } from './email-editor'
 
 export async function EditableEmail() {
-  const { data: currentUser } = await getCurrentUser()
+  const { account: currentUser } = await getCurrentUser()
   const currentUserId = currentUser.id.toString()
 
   return (

--- a/src/components/pages/account-page/current-user-info/editable-name/index.tsx
+++ b/src/components/pages/account-page/current-user-info/editable-name/index.tsx
@@ -10,7 +10,7 @@ import { getCurrentUser } from '@/utils/api/server/get-current-user'
 import { NameEditor } from './name-editor'
 
 export async function EditableName() {
-  const { data: currentUser } = await getCurrentUser()
+  const { account: currentUser } = await getCurrentUser()
   const currentUserId = currentUser.id.toString()
 
   return (

--- a/src/components/pages/account-page/current-user-info/private-mode-switch/index.tsx
+++ b/src/components/pages/account-page/current-user-info/private-mode-switch/index.tsx
@@ -8,7 +8,7 @@ import {
 const descriptionLayoutClasses = 'ml-3 align-middle'
 
 export async function PrivateModeSwitch() {
-  const { data: currentUser } = await getCurrentUser()
+  const { account: currentUser } = await getCurrentUser()
 
   return (
     <PrivateModeCheckbox

--- a/src/components/pages/account-page/delete-current-user-account-button/index.tsx
+++ b/src/components/pages/account-page/delete-current-user-account-button/index.tsx
@@ -2,7 +2,7 @@ import { getCurrentUser } from '@/utils/api/server/get-current-user'
 import { DeleteAccountButton } from './delete-account-button'
 
 export async function DeleteCurrentUserAccountButton() {
-  const { data: currentUser } = await getCurrentUser()
+  const { account: currentUser } = await getCurrentUser()
   const currentUserId = currentUser.id.toString()
 
   return <DeleteAccountButton currentUserId={currentUserId} />

--- a/src/schemas/response/account.ts
+++ b/src/schemas/response/account.ts
@@ -8,5 +8,6 @@ export const accountSchema = z.object({
     is_private: z.boolean(),
     bio: z.string().optional(),
     avatar_url: z.string().optional(),
+    provider: z.string(),
   }),
 })


### PR DESCRIPTION
### Summary

<!-- Briefly describe the purpose of the pull request and the changes it introduces -->
An error occurs when transitioning to the account page due to backend changes.

![screen-shot-194-1](https://github.com/user-attachments/assets/5f6cb49b-4af7-427c-9317-da041c976781)

The frontend code is modified to match the backend changes to ensure the account page displays correctly.

### Changes

<!-- Explain the specific changes or additions made -->
- Changed `EditableAvatar`'s `data` to `account`
- Changed `AvatarEditor`'s `avatarUrl` type to optional
  These changes resolve the error occurring in `EditableAvatar` when transitioning to the account page.

---

- Changed `EditableName`'s `data` to `account`
  This change resolves the error occurring in `EditableName` when transitioning to the account page.

---

- Changed `EditableBio`'s `data` to `account`
- Changed the condition for managing the display of the bio introduction from `''` to `undefined`
- Changed `BioEditor`'s `initialBio` type from `string` to `string | undefined`
- Set an empty string as the default value for `BioEditor`'s `initialBio`
  These changes resolve the error occurring in `EditableBio` when transitioning to the account page.

---

- Changed `EditableEmail`'s `data` to `account`
- Added `provider` to `accountSchema`
  These changes resolve the error occurring in `EditableEmail` when transitioning to the account page.

---

- Changed `PrivateModeSwitch`'s `data` to `account`
  This change resolves the error occurring in `PrivateModeSwitch` when transitioning to the account page.

---

- Changed `CurrentUserChangePasswordFormShowButton`'s `data` to `account`
  This change resolves the error occurring in `CurrentUserChangePasswordFormShowButton` when transitioning to the account page.

---

- Changed `DeleteCurrentUserAccountButton`'s `data` to `account`
  This change resolves the error occurring in `DeleteCurrentUserAccountButton` when transitioning to the account page.

### Testing

<!-- Describe how the changes were tested to ensure they work as expected -->
It was confirmed that the account page can be transitioned to without errors as shown in the following image.

![screen-shot-200](https://github.com/user-attachments/assets/718e914b-0ae8-447a-8209-b8478baf8eff)

### Related Issues (Optional)

<!-- Mention any related issue numbers (excluding task management issue) -->
N/A

### Notes (Optional)

<!-- Include any additional information or considerations -->
No additional information or considerations at this time.
