### PR TITLE
fix: fix the error that occurs when changing the user name

### DIFF
--- a/src/components/pages/account-page/current-user-info/editable-name/name-editor/change-name.api.ts
+++ b/src/components/pages/account-page/current-user-info/editable-name/name-editor/change-name.api.ts
@@ -2,7 +2,7 @@
 
 import camelcaseKeys from 'camelcase-keys'
 import { revalidatePath } from 'next/cache'
-import { changeUserInfoDataSchema } from '@/schemas/response/change-user-info-success'
+import { accountSchema } from '@/schemas/response/account'
 import { ResultObject, ChangeUserInfoData } from '@/types/api'
 import { fetchData } from '@/utils/api/fetch-data'
 import { getBearerToken } from '@/utils/cookie/bearer-token'
@@ -14,7 +14,7 @@ type Params = {
   name: string
 }
 
-export async function changeName({ ...bodyData }: Params) {
+export async function changeName(bodyData: Params) {
   const fetchDataResult = await fetchData(
     `${process.env.API_ORIGIN}/api/v1/auth`,
     {
@@ -36,14 +36,17 @@ export async function changeName({ ...bodyData }: Params) {
     const requestId = getRequestId(headers)
     const validateDataResult = validateData({
       requestId,
-      dataSchema: changeUserInfoDataSchema,
+      dataSchema: accountSchema,
       data,
     })
 
     if (validateDataResult instanceof Error) {
       resultObject = createErrorObject(validateDataResult)
     } else {
-      resultObject = camelcaseKeys(validateDataResult, { deep: true })
+      resultObject = {
+        status: 'success',
+        ...camelcaseKeys(validateDataResult, { deep: true }),
+      }
       revalidatePath('/account')
     }
   }

--- a/src/components/pages/account-page/current-user-info/editable-name/name-editor/index.tsx
+++ b/src/components/pages/account-page/current-user-info/editable-name/name-editor/index.tsx
@@ -87,7 +87,7 @@ export function NameEditor({
         openErrorSnackbar(result)
       }
     } else {
-      updateField(result.data.name)
+      updateField(result.account.name)
       closeEditor()
     }
   }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,7 +1,7 @@
-import { z } from 'zod'
-import { changeUserInfoDataSchema } from '@/schemas/response/change-user-info-success'
 import type { ErrorObject, Errors } from './error'
+import type { accountSchema } from '@/schemas/response/account'
 import type { CamelCaseKeys } from 'camelcase-keys'
+import type { z } from 'zod'
 
 export type ResultObject<T extends Record<string, unknown>> =
   | (T extends { status: 'success' } & Record<string, unknown>
@@ -10,6 +10,6 @@ export type ResultObject<T extends Record<string, unknown>> =
   | ErrorObject<Errors>
 
 export type ChangeUserInfoData = CamelCaseKeys<
-  z.infer<typeof changeUserInfoDataSchema>,
+  z.infer<typeof accountSchema>,
   true
 >


### PR DESCRIPTION
### Summary

<!-- Briefly describe the purpose of the pull request and the changes it introduces -->

A backend change causes a Zod validation error when changing the username on the account page. To correct this error, change the schema of the user name change response.

### Changes

<!-- Explain the specific changes or additions made -->
- Changed the Zod schema for the `changeName` response from `changeUserInfoDataSchema` to `accountSchema`. 
  This change resolves the error when changing the username.

### Testing

<!-- Describe how the changes were tested to ensure they work as expected -->
As shown in the following image, it was confirmed that the username can be changed successfully.

![screen-recording-2](https://github.com/user-attachments/assets/e029e793-ec5e-4493-bde3-9d6a135cb4b3)

### Related Issues (Optional)

<!-- Mention any related issue numbers (excluding task management issue) -->
N/A

### Notes (Optional)

<!-- Include any additional information or considerations -->
No additional information or considerations at this time.