### PR TITLE
fix: fix the error that occurs when changing the avatar

### DIFF
--- a/src/components/pages/account-page/current-user-info/editable-avatar/avatar-editor/change-avatar.api.ts
+++ b/src/components/pages/account-page/current-user-info/editable-avatar/avatar-editor/change-avatar.api.ts
@@ -2,7 +2,7 @@
 
 import camelcaseKeys from 'camelcase-keys'
 import { revalidatePath } from 'next/cache'
-import { changeUserInfoDataSchema } from '@/schemas/response/change-user-info-success'
+import { accountSchema } from '@/schemas/response/account'
 import { fetchData } from '@/utils/api/fetch-data'
 import { getBearerToken } from '@/utils/cookie/bearer-token'
 import { createErrorObject } from '@/utils/error/create-error-object'
@@ -45,14 +45,18 @@ export async function changeAvatar({ formData }: Params) {
     const requestId = getRequestId(resHeaders)
     const validateDataResult = validateData({
       requestId,
-      dataSchema: changeUserInfoDataSchema,
+      dataSchema: accountSchema,
       data,
     })
 
     if (validateDataResult instanceof Error) {
       resultObject = createErrorObject(validateDataResult)
     } else {
-      resultObject = camelcaseKeys(validateDataResult, { deep: true })
+      resultObject = {
+        status: 'success',
+        ...camelcaseKeys(validateDataResult, { deep: true }),
+      }
+
       revalidatePath('/account')
     }
   }


### PR DESCRIPTION
### Summary

<!-- Briefly describe the purpose of the pull request and the changes it introduces -->

A backend change causes a Zod validation error when changing the avatar on the account page. To correct this error, change the schema of the avatar change response.

### Changes

<!-- Explain the specific changes or additions made -->
- Changed the Zod schema for the `changeAvatar` response from `changeUserInfoDataSchema` to `accountSchema`. 
  This change resolves the error when changing the avatar.

### Testing

<!-- Describe how the changes were tested to ensure they work as expected -->
As shown in the following image, it was confirmed that the avatar can be changed successfully.

![screen-recording-1](https://github.com/user-attachments/assets/46e33498-bfd0-477b-875f-cfc14676ed69)

### Related Issues (Optional)

<!-- Mention any related issue numbers (excluding task management issue) -->
N/A

### Notes (Optional)

<!-- Include any additional information or considerations -->
No additional information or considerations at this time.