### PR TITLE
fix: fix the error that occurs when changing the bio

### DIFF
--- a/src/components/pages/account-page/current-user-info/editable-bio/bio-editor/change-bio.api.ts
+++ b/src/components/pages/account-page/current-user-info/editable-bio/bio-editor/change-bio.api.ts
@@ -2,7 +2,7 @@
 
 import camelcaseKeys from 'camelcase-keys'
 import { revalidatePath } from 'next/cache'
-import { changeUserInfoDataSchema } from '@/schemas/response/change-user-info-success'
+import { accountSchema } from '@/schemas/response/account'
 import { ChangeUserInfoData, ResultObject } from '@/types/api'
 import { fetchData } from '@/utils/api/fetch-data'
 import { getBearerToken } from '@/utils/cookie/bearer-token'
@@ -14,7 +14,7 @@ type Params = {
   bio: string
 }
 
-export async function changeBio({ ...bodyData }: Params) {
+export async function changeBio(bodyData: Params) {
   const fetchDataResult = await fetchData(
     `${process.env.API_ORIGIN}/api/v1/auth`,
     {
@@ -36,14 +36,17 @@ export async function changeBio({ ...bodyData }: Params) {
     const requestId = getRequestId(headers)
     const validateDataResult = validateData({
       requestId,
-      dataSchema: changeUserInfoDataSchema,
+      dataSchema: accountSchema,
       data,
     })
 
     if (validateDataResult instanceof Error) {
       resultObject = createErrorObject(validateDataResult)
     } else {
-      resultObject = camelcaseKeys(validateDataResult, { deep: true })
+      resultObject = {
+        status: 'success',
+        ...camelcaseKeys(validateDataResult, { deep: true }),
+      }
       revalidatePath('/account')
     }
   }

--- a/src/components/pages/account-page/current-user-info/editable-bio/bio-editor/index.tsx
+++ b/src/components/pages/account-page/current-user-info/editable-bio/bio-editor/index.tsx
@@ -101,7 +101,7 @@ export function BioEditor({
         openErrorSnackbar(result)
       }
     } else {
-      updateField(result.data.bio)
+      updateField(result.account.bio ?? '')
       closeEditor()
     }
   }

--- a/src/components/pages/account-page/current-user-info/editable-bio/index.tsx
+++ b/src/components/pages/account-page/current-user-info/editable-bio/index.tsx
@@ -27,7 +27,7 @@ export async function EditableBio() {
       {/* Pass 'key' so that the bio is re-rendered when it is re-validated */}
       <BioCollapsibleSection key={currentUser.bio} height={height}>
         <DetailItemContentLayout>
-          {currentUser.bio === undefined ? (
+          {currentUser.bio === '' || currentUser.bio === undefined ? (
             <p className="text-gray-500">自己紹介を登録してください...</p>
           ) : (
             <DetailMultiLineText>{currentUser.bio}</DetailMultiLineText>


### PR DESCRIPTION
### Summary

<!-- Briefly describe the purpose of the pull request and the changes it introduces -->

A backend change causes a Zod validation error when changing the bio on the account page. To correct this error, change the schema of the bio change response.

### Changes

<!-- Explain the specific changes or additions made -->
- Changed the Zod schema for the `changeBio` response from `changeUserInfoDataSchema` to `accountSchema`. 
  This change resolves the error when changing the bio.

- Added an empty string as a condition to control the prompt and bio display in `EditableBio`.
  This change resolves the problem of not prompting when the bio is changed to an empty string.

### Testing

<!-- Describe how the changes were tested to ensure they work as expected -->
As shown in the following image, it was confirmed that the bio can be changed successfully.

![screen-recording-9](https://github.com/user-attachments/assets/f49ddb53-156a-46d5-b88f-53ec2a77daf5)

### Related Issues (Optional)

<!-- Mention any related issue numbers (excluding task management issue) -->
N/A

### Notes (Optional)

<!-- Include any additional information or considerations -->
No additional information or considerations at this time.