### PR TITLE
fix: fix the error that occurs when changing the email address

### DIFF
--- a/src/components/pages/account-page/current-user-info/editable-email/email-editor/change-email.api.ts
+++ b/src/components/pages/account-page/current-user-info/editable-email/email-editor/change-email.api.ts
@@ -2,7 +2,7 @@
 
 import camelcaseKeys from 'camelcase-keys'
 import snakecaseKeys from 'snakecase-keys'
-import { changeUserInfoDataSchema } from '@/schemas/response/change-user-info-success'
+import { accountSchema } from '@/schemas/response/account'
 import { ChangeUserInfoData, ResultObject } from '@/types/api'
 import { fetchData } from '@/utils/api/fetch-data'
 import { getBearerToken } from '@/utils/cookie/bearer-token'
@@ -36,14 +36,17 @@ export async function changeEmail({ ...bodyData }: Params) {
     const requestId = getRequestId(headers)
     const validateDataResult = validateData({
       requestId,
-      dataSchema: changeUserInfoDataSchema,
+      dataSchema: accountSchema,
       data,
     })
 
     if (validateDataResult instanceof Error) {
       resultObject = createErrorObject(validateDataResult)
     } else {
-      resultObject = camelcaseKeys(validateDataResult, { deep: true })
+      resultObject = {
+        status: 'success',
+        ...camelcaseKeys(validateDataResult, { deep: true }),
+      }
     }
   }
 

--- a/src/components/pages/account-page/current-user-info/editable-email/email-editor/index.tsx
+++ b/src/components/pages/account-page/current-user-info/editable-email/email-editor/index.tsx
@@ -100,7 +100,7 @@ export function EmailEditor({
         openErrorSnackbar(result)
       }
     } else {
-      updateField(result.data.email)
+      updateField(result.account.email)
       closeEditor()
       openSnackbar({
         severity: 'success',


### PR DESCRIPTION
### Summary

<!-- Briefly describe the purpose of the pull request and the changes it introduces -->
Due to changes in the backend, an error occurs on the account page when changing the email address, as shown in the following image.

![screen-shot-202](https://github.com/user-attachments/assets/b63ae55e-ba0f-4a8e-add6-c26116ad1cdb)

This is caused by a Zod validation error.
To fix this, the Zod schema for the response when changing the email address will be modified.

### Changes

<!-- Explain the specific changes or additions made -->
- The Zod schema for response validation of `changeEmail` was changed from `changeUserInfoDataSchema` to `accountSchema`.
  This change will resolve the error that occurs when changing the email address.

### Testing

<!-- Describe how the changes were tested to ensure they work as expected -->
It was confirmed that the confirmation email for changing the email address is sent normally, as shown in the following image.

![screen-recording-13](https://github.com/user-attachments/assets/da2e7e9e-4969-4195-b47e-142cd5dd8443)

### Related Issues (Optional)

<!-- Mention any related issue numbers (excluding task management issue) -->
N/A

### Notes (Optional)

<!-- Include any additional information or considerations -->
No additional information or considerations at this time.