### PR TITLE
fix: fix the error that occurs when switching private mode

### DIFF
--- a/src/components/pages/account-page/current-user-info/private-mode-switch/private-mode-checkbox/change-is-private.api.ts
+++ b/src/components/pages/account-page/current-user-info/private-mode-switch/private-mode-checkbox/change-is-private.api.ts
@@ -3,7 +3,7 @@
 import camelcaseKeys from 'camelcase-keys'
 import { revalidatePath } from 'next/cache'
 import snakecaseKeys from 'snakecase-keys'
-import { changeUserInfoDataSchema } from '@/schemas/response/change-user-info-success'
+import { accountSchema } from '@/schemas/response/account'
 import { ChangeUserInfoData, ResultObject } from '@/types/api'
 import { fetchData } from '@/utils/api/fetch-data'
 import { getBearerToken } from '@/utils/cookie/bearer-token'
@@ -37,14 +37,18 @@ export async function changeIsPrivate({ ...bodyData }: Params) {
     const requestId = getRequestId(headers)
     const validateDataResult = validateData({
       requestId,
-      dataSchema: changeUserInfoDataSchema,
+      dataSchema: accountSchema,
       data,
     })
 
     if (validateDataResult instanceof Error) {
       resultObject = createErrorObject(validateDataResult)
     } else {
-      resultObject = camelcaseKeys(validateDataResult, { deep: true })
+      resultObject = {
+        status: 'success',
+        ...camelcaseKeys(validateDataResult, { deep: true }),
+      }
+
       revalidatePath('/account')
     }
   }


### PR DESCRIPTION
### Summary

<!-- Briefly describe the purpose of the pull request and the changes it introduces -->
Due to changes in the backend, an error occurs on the account page when switching the private mode, as shown in the following image.

![screen-shot-203](https://github.com/user-attachments/assets/2499b28a-dbd6-4808-97b0-d35d3518e4e4)

This is caused by a Zod validation error.
To fix this, the Zod schema for the response when switching the private mode will be modified.

### Changes

<!-- Explain the specific changes or additions made -->
- The Zod schema for response validation of `changeIsPrivate` was changed from `changeUserInfoDataSchema` to `accountSchema`.
  This change will resolve the error that occurs when switching the private mode.

### Testing

<!-- Describe how the changes were tested to ensure they work as expected -->
As shown in the image below, we have confirmed that the private mode can be switched without any errors.

![screen-recording-14](https://github.com/user-attachments/assets/e9252ed5-0907-4ddf-a89c-e00eb36f6594)

### Related Issues (Optional)

<!-- Mention any related issue numbers (excluding task management issue) -->
N/A

### Notes (Optional)

<!-- Include any additional information or considerations -->
No additional information or considerations at this time.