### PR TITLE
fix: fix error during account deletion

### DIFF
--- a/src/components/pages/account-page/delete-current-user-account-button/delete-account-button/delete-account.api.ts
+++ b/src/components/pages/account-page/delete-current-user-account-button/delete-account-button/delete-account.api.ts
@@ -8,10 +8,7 @@ import { createErrorObject } from '@/utils/error/create-error-object'
 import { getRequestId } from '@/utils/request-id/get-request-id'
 import { validateData } from '@/utils/validation/validate-data'
 
-const dataSchema = z.object({
-  status: z.literal('success'),
-  message: z.string(),
-})
+const dataSchema = z.null()
 
 type Data = z.infer<typeof dataSchema>
 
@@ -39,7 +36,7 @@ export async function deleteAccount() {
     if (validateDataResult instanceof Error) {
       resultObject = createErrorObject(validateDataResult)
     } else {
-      resultObject = validateDataResult
+      resultObject = { status: 'success' }
       deleteBearerToken()
     }
   }


### PR DESCRIPTION
### Summary
<!-- Briefly describe the purpose of the pull request and the changes it introduces -->
Due to backend updates, a Zod validation error started occurring during account deletion. To resolve this, the response validation schema for `deleteAccount` has been modified.


<details>
<summary>Error</summary>

```shell
FATAL (tascon-frontend/18): Validation failed due to schema mismatch.
    err: {
      "type": "ValidationError",
      "message": "Validation failed due to schema mismatch.: [\n  {\n    \"code\": \"invalid_type\",\n    \"expected\": \"object\",\n    \"received\": \"null\",\n    \"path\": [],\n    \"message\": \"Expected object, received null\"\n  }\n]",
      "stack":
          ValidationError: Validation failed due to schema mismatch.
              at createValidationError (webpack-internal:///(action-browser)/./src/utils/error/create-validation-error.ts:10:29)
              at validateData (webpack-internal:///(action-browser)/./src/utils/validation/validate-data.ts:17:105)
              at deleteAccount (webpack-internal:///(action-browser)/./src/components/pages/account-page/delete-current-user-account-button/delete-account-button/delete-account.api.ts:41:113)
              at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
              at async /home/node/tascon-frontend/node_modules/next/dist/compiled/next-server/app-page.runtime.dev.js:39:418
              at async rk (/home/node/tascon-frontend/node_modules/next/dist/compiled/next-server/app-page.runtime.dev.js:38:8148)
              at async r3 (/home/node/tascon-frontend/node_modules/next/dist/compiled/next-server/app-page.runtime.dev.js:41:1256)
              at async doRender (/home/node/tascon-frontend/node_modules/next/dist/server/base-server.js:1413:30)
              at async cacheEntry.responseCache.get.routeKind (/home/node/tascon-frontend/node_modules/next/dist/server/base-server.js:1574:28)
              at async DevServer.renderToResponseWithComponentsImpl (/home/node/tascon-frontend/node_modules/next/dist/server/base-server.js:1482:28)
              at async DevServer.renderPageComponent (/home/node/tascon-frontend/node_modules/next/dist/server/base-server.js:1908:24)
              at async DevServer.renderToResponseImpl (/home/node/tascon-frontend/node_modules/next/dist/server/base-server.js:1946:32)
              at async DevServer.pipeImpl (/home/node/tascon-frontend/node_modules/next/dist/server/base-server.js:921:25)
              at async NextNodeServer.handleCatchallRenderRequest (/home/node/tascon-frontend/node_modules/next/dist/server/next-server.js:272:17)
              at async DevServer.handleRequestImpl (/home/node/tascon-frontend/node_modules/next/dist/server/base-server.js:817:17)
              at async /home/node/tascon-frontend/node_modules/next/dist/server/dev/next-dev-server.js:339:20
              at async Span.traceAsyncFn (/home/node/tascon-frontend/node_modules/next/dist/trace/trace.js:154:20)
              at async DevServer.handleRequest (/home/node/tascon-frontend/node_modules/next/dist/server/dev/next-dev-server.js:336:24)
              at async invokeRender (/home/node/tascon-frontend/node_modules/next/dist/server/lib/router-server.js:173:21)
              at async handleRequest (/home/node/tascon-frontend/node_modules/next/dist/server/lib/router-server.js:350:24)
              at async requestHandlerImpl (/home/node/tascon-frontend/node_modules/next/dist/server/lib/router-server.js:374:13)
              at async Server.requestListener (/home/node/tascon-frontend/node_modules/next/dist/server/lib/start-server.js:141:13)
          caused by: ZodError: [
            {
              "code": "invalid_type",
              "expected": "object",
              "received": "null",
              "path": [],
              "message": "Expected object, received null"
            }
          ]
              at get error (webpack-internal:///(action-browser)/./node_modules/zod/lib/index.mjs:699:31)
              at ZodObject.parse (webpack-internal:///(action-browser)/./node_modules/zod/lib/index.mjs:775:22)
              at validateValue (webpack-internal:///(action-browser)/./src/utils/type-guard/validate-value.ts:6:12)
              at validateData (webpack-internal:///(action-browser)/./src/utils/validation/validate-data.ts:13:82)
              at deleteAccount (webpack-internal:///(action-browser)/./src/components/pages/account-page/delete-current-user-account-button/delete-account-button/delete-account.api.ts:41:113)
              at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
              at async /home/node/tascon-frontend/node_modules/next/dist/compiled/next-server/app-page.runtime.dev.js:39:418
              at async rk (/home/node/tascon-frontend/node_modules/next/dist/compiled/next-server/app-page.runtime.dev.js:38:8148)
              at async r3 (/home/node/tascon-frontend/node_modules/next/dist/compiled/next-server/app-page.runtime.dev.js:41:1256)
              at async doRender (/home/node/tascon-frontend/node_modules/next/dist/server/base-server.js:1413:30)
              at async cacheEntry.responseCache.get.routeKind (/home/node/tascon-frontend/node_modules/next/dist/server/base-server.js:1574:28)
              at async DevServer.renderToResponseWithComponentsImpl (/home/node/tascon-frontend/node_modules/next/dist/server/base-server.js:1482:28)
              at async DevServer.renderPageComponent (/home/node/tascon-frontend/node_modules/next/dist/server/base-server.js:1908:24)
              at async DevServer.renderToResponseImpl (/home/node/tascon-frontend/node_modules/next/dist/server/base-server.js:1946:32)
              at async DevServer.pipeImpl (/home/node/tascon-frontend/node_modules/next/dist/server/base-server.js:921:25)
              at async NextNodeServer.handleCatchallRenderRequest (/home/node/tascon-frontend/node_modules/next/dist/server/next-server.js:272:17)
              at async DevServer.handleRequestImpl (/home/node/tascon-frontend/node_modules/next/dist/server/base-server.js:817:17)
              at async /home/node/tascon-frontend/node_modules/next/dist/server/dev/next-dev-server.js:339:20
              at async Span.traceAsyncFn (/home/node/tascon-frontend/node_modules/next/dist/trace/trace.js:154:20)
              at async DevServer.handleRequest (/home/node/tascon-frontend/node_modules/next/dist/server/dev/next-dev-server.js:336:24)
              at async invokeRender (/home/node/tascon-frontend/node_modules/next/dist/server/lib/router-server.js:173:21)
              at async handleRequest (/home/node/tascon-frontend/node_modules/next/dist/server/lib/router-server.js:350:24)
              at async requestHandlerImpl (/home/node/tascon-frontend/node_modules/next/dist/server/lib/router-server.js:374:13)
              at async Server.requestListener (/home/node/tascon-frontend/node_modules/next/dist/server/lib/start-server.js:141:13)
      "name": "ValidationError",
      "requestId": "2b600ce4-79a5-415a-b062-c5c22d40ef49"
    }
```

</details>



### Changes
<!-- Explain the specific changes or additions made -->
- The Zod schema for response validation of `deleteAccount` has been changed to `null`.
	This change will fix the error that was occurring during account deletion.

### Testing
<!-- Describe how the changes were tested to ensure they work as expected -->
The account deletion process was executed to confirm that the account is successfully deleted.

### Related Issues (Optional)
<!-- Mention any related issue numbers (excluding task management issue) -->
N/A

### Notes (Optional)
<!-- Include any additional information or considerations -->
No additional information or considerations at this time.
