### PR TITLE
fix: fix the error that occurs when resending the confirmation email

### DIFF
--- a/src/app/(auth)/sign-up/_components/sign-up-form/sign-up-success-message/resend-confirmation-email.api.ts
+++ b/src/app/(auth)/sign-up/_components/sign-up-form/sign-up-success-message/resend-confirmation-email.api.ts
@@ -12,14 +12,11 @@ type Params = {
   email: string
 }
 
-const dataSchema = z.object({
-  success: z.literal(true),
-  message: z.string(),
-})
+const dataSchema = z.null()
 
 type Data = z.infer<typeof dataSchema>
 
-export async function resendConfirmationEmail({ ...bodyData }: Params) {
+export async function resendConfirmationEmail(bodyData: Params) {
   const fetchDataResult = await fetchData(
     `${process.env.API_ORIGIN}/api/v1/auth/confirmation`,
     {
@@ -47,10 +44,7 @@ export async function resendConfirmationEmail({ ...bodyData }: Params) {
     if (validateDataResult instanceof Error) {
       resultObject = createErrorObject(validateDataResult)
     } else {
-      resultObject = {
-        status: 'success',
-        ...validateDataResult,
-      }
+      resultObject = { status: 'success' }
     }
   }
 


### PR DESCRIPTION
### Summary

<!-- Briefly describe the purpose of the pull request and the changes it introduces -->

Due to backend changes, an error occurs when clicking the "確認用メールを再送信" button after successful signup.
To address this, we will modify the Zod schema for response validation of `resendConfirmationEmail`.

![screen-shot-274](https://github.com/user-attachments/assets/37c9deef-4bdc-4277-bec8-839428c365fc)


### Changes

<!-- Explain the specific changes or additions made -->

- The Zod schema for response validation of `resendConfirmationEmail` has been changed to `null`.
​	This change will resolve the error occurring when clicking the "確認用メールを再送信" button.

### Testing

<!-- Describe how the changes were tested to ensure they work as expected -->

As shown in the following image, it has been confirmed that the confirmation email is successfully resent.
![screen-recording-28](https://github.com/user-attachments/assets/344a9af4-2eaf-4066-bd3d-a95f72dae3b5)

### Related Issues (Optional)

<!-- Mention any related issue numbers (excluding task management issue) -->

N/A

### Notes (Optional)

<!-- Include any additional information or considerations -->

No additional information or considerations at this time.