### PR TITLE
fix: fix account page UI

### DIFF
--- a/src/app/(main)/_components/main-header/account-avatar-link/account-link/index.tsx
+++ b/src/app/(main)/_components/main-header/account-avatar-link/account-link/index.tsx
@@ -15,7 +15,7 @@ export function AccountLink({ children }: Props) {
     <Link
       href="/account"
       className={`clickable-avatar ${
-        isActive ? 'pointer-events-none ring ring-gray-500' : ''
+        isActive ? 'pointer-events-none ring-3 ring-gray-500' : ''
       }`}
       aria-label="アカウント"
       prefetch={!isActive}

--- a/src/app/(main)/_components/main-header/index.tsx
+++ b/src/app/(main)/_components/main-header/index.tsx
@@ -8,7 +8,7 @@ import { NavLinks } from './nav-links'
 
 export function MainHeader() {
   return (
-    <header className="border-b bg-theme px-safe">
+    <header className="bg-theme px-safe border-b border-b-gray-200">
       <nav className="px-2">
         <div className="flex justify-between py-1">
           <div className="flex flex-row">
@@ -29,7 +29,7 @@ export function MainHeader() {
             </Suspense>
           </AccountLink>
         </div>
-        <NavLinks className="justify-between overflow-scroll whitespace-nowrap py-1 text-sm hidden-scrollbar md:hidden" />
+        <NavLinks className="hidden-scrollbar justify-between overflow-scroll py-1 text-sm whitespace-nowrap md:hidden" />
       </nav>
     </header>
   )

--- a/src/components/tag/index.tsx
+++ b/src/components/tag/index.tsx
@@ -12,7 +12,7 @@ const colorClasses = {
 export function Tag({ className = '', color, children }: Props) {
   return (
     <span
-      className={`rounded-sm border px-2 py-0.5 text-xs ${colorClasses[color]} ${className}`}
+      className={`rounded-sm border border-gray-200 px-2 py-0.5 text-xs ${colorClasses[color]} ${className}`}
     >
       {children}
     </span>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -118,7 +118,9 @@ module.exports = {
           '@apply mb-1 text-sm font-bold': {},
         },
         '.text-box': {
-          '@apply block min-h-[2.75rem] w-full rounded-none border border-gray-300 px-2.5 focus:border-blue-600 focus:outline-none':
+          // TEMP: Add 'bg-white' to avoid the background becoming transparent.
+          //   See https://github.com/tailwindlabs/tailwindcss/issues/17646
+          '@apply block min-h-[2.75rem] w-full rounded-none border border-gray-300 px-2.5 focus:border-blue-600 focus:outline-none bg-white':
             {},
         },
         '.text-box-error': {
@@ -159,7 +161,8 @@ module.exports = {
             {},
         },
         '.btn-outline-disabled': {
-          '@apply cursor-not-allowed border-2 border-gray-400 text-gray-400': {},
+          '@apply cursor-not-allowed border-2 border-gray-400 text-gray-400':
+            {},
         },
         '.btn-outline-danger': {
           '@apply btn-shadow border-2 border-red-600 bg-white text-red-600 disabled:btn-outline-disabled disabled:duration-0':


### PR DESCRIPTION
### Summary

<!-- Briefly describe the purpose of the pull request and the changes it introduces -->

Updating TailwindCSS caused some UI elements to be displayed incorrectly as shown in the following image.

![screen-shot-279](https://github.com/user-attachments/assets/a2b40e80-e7f5-4416-bb95-03999d91ff9c)

To fix this, the TailwindCSS class names for each UI element is corrected.

### Changes

<!-- Explain the specific changes or additions made -->

- Explicitly specified the color of the header border
	This change will correct the color of the header border.
	![screen-shot-280](https://github.com/user-attachments/assets/6b83c4f9-e201-4b37-93ae-d9c468530731)

- Changed the class for the account link ring to `ring-3`
  This change will correct the width of the ring around the account link when the account page is displayed.
  ![screen-shot-281](https://github.com/user-attachments/assets/742d7f61-8774-48a5-a3df-435409f56ab8)

- Explicitly specified the color of the Tag border
  This change will correct the color of the Tag border.
  ![screen-shot-289](https://github.com/user-attachments/assets/0218ac62-d206-4447-a839-77781b0620a4)

- Added `bg-white` to `text-box`
  This change will correct the background color of the input field.
  ![screen-shot-288](https://github.com/user-attachments/assets/7b677e9f-0623-4b20-ae08-da4fe87f08d5)

### Testing

<!-- Describe how the changes were tested to ensure they work as expected -->

It was confirmed that the account page is displayed normally as shown in the following image.

![screen-shot-288](https://github.com/user-attachments/assets/7b677e9f-0623-4b20-ae08-da4fe87f08d5)

### Related Issues (Optional)

<!-- Mention any related issue numbers (excluding task management issue) -->

N/A

### Notes (Optional)

<!-- Include any additional information or considerations -->

No additional information or considerations at this time.
