### PR TITLE
fix: correct the display of error messages when changing the email

### DIFF
--- a/src/components/editable-text/use-editable-text.tsx
+++ b/src/components/editable-text/use-editable-text.tsx
@@ -2,13 +2,14 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { usePathname } from 'next/navigation'
 import { useState, useCallback, useEffect, useRef } from 'react'
 import { useForm } from 'react-hook-form'
+import { useHandleFormErrors } from '@/utils/form/use-handle-form-error'
 import { useLocalStorage } from '@/utils/local-storage/use-local-storage'
 import type {
   UseEditableTextParams,
   FormSubmitHandler,
   BlurHandler,
 } from './use-editable-text.types'
-import type { FieldError, FieldValues, SubmitHandler } from 'react-hook-form'
+import type { FieldValues, SubmitHandler } from 'react-hook-form'
 
 export function useEditableText<T extends FieldValues>({
   editorRef,
@@ -39,6 +40,7 @@ export function useEditableText<T extends FieldValues>({
       [name]: defaultValue,
     },
   })
+  const { handleFormErrors } = useHandleFormErrors(setError)
   const {
     hasLocalStorageValue,
     saveToLocalStorage,
@@ -53,13 +55,6 @@ export function useEditableText<T extends FieldValues>({
   const closeEditor = useCallback(() => {
     setIsEditorOpen(false)
   }, [])
-
-  const setFieldError = useCallback(
-    (error: FieldError) => {
-      setError(name, error)
-    },
-    [setError, name],
-  )
 
   const updateField = useCallback(
     (value: string) => {
@@ -161,7 +156,7 @@ export function useEditableText<T extends FieldValues>({
     fieldError: errors[name],
     closeEditor,
     openEditor,
-    setFieldError,
+    handleFormErrors,
     updateField,
     handleFormSubmit,
     handleBlur,

--- a/src/components/pages/account-page/current-user-info/editable-email/email-editor/change-email.api.ts
+++ b/src/components/pages/account-page/current-user-info/editable-email/email-editor/change-email.api.ts
@@ -15,7 +15,7 @@ type Params = {
   confirmSuccessUrl: string
 }
 
-export async function changeEmail({ ...bodyData }: Params) {
+export async function changeEmail(bodyData: Params) {
   const fetchDataResult = await fetchData(
     `${process.env.API_ORIGIN}/api/v1/auth`,
     {

--- a/src/utils/form/use-handle-form-error.tsx
+++ b/src/utils/form/use-handle-form-error.tsx
@@ -7,19 +7,16 @@ type FormErrors<T extends FieldValues = FieldValues> = {
     type: string
     full_message: string
   }>
+  shouldFocus?: boolean
 }
 
 export function useHandleFormErrors<T extends FieldValues = FieldValues>(
   setError: UseFormSetError<T>,
 ) {
   const handleFormErrors = useCallback(
-    ({ errors }: FormErrors<T>) => {
+    ({ errors, shouldFocus = true }: FormErrors<T>) => {
       errors.forEach(({ attribute, type, full_message }) => {
-        setError(
-          attribute,
-          { type, message: full_message },
-          { shouldFocus: true },
-        )
+        setError(attribute, { type, message: full_message }, { shouldFocus })
       })
     },
     [setError],


### PR DESCRIPTION
### Summary

<!-- Briefly describe the purpose of the pull request and the changes it introduces -->

The error message returned from the backend is not displayed when processing email address changes.
![screen-shot-290](https://github.com/user-attachments/assets/affdcf6a-52b8-44de-b499-44deb83849a1)

To fix this, the code in `EmailEditor` to display error messages returned from the backend will be modified.

### Changes

<!-- Explain the specific changes or additions made -->

- Changed `handleHttpError` in `EmailEditor` to use `handleFormErrors`
  This change will allow error messages returned from the backend to be displayed in the email address change form.

### Testing

<!-- Describe how the changes were tested to ensure they work as expected -->

As shown in the following image, it was confirmed that the error message is displayed correctly.
![screen-recording-29](https://github.com/user-attachments/assets/004d2da6-413d-41da-8808-32e495bdb433)

### Related Issues (Optional)

<!-- Mention any related issue numbers (excluding task management issue) -->

N/A

### Notes (Optional)

<!-- Include any additional information or considerations -->

No additional information or considerations at this time.
