### PR TITLE
refactor: remove the code for displaying backend validation error messages when changing the bio

### DIFF
--- a/src/components/pages/account-page/current-user-info/editable-bio/bio-editor/index.tsx
+++ b/src/components/pages/account-page/current-user-info/editable-bio/bio-editor/index.tsx
@@ -56,7 +56,6 @@ export function BioEditor({
     handleCancelClick,
     registerReturn,
     fieldError,
-    setFieldError,
     closeEditor,
     saveFieldValueToLocalStorage,
     ...rest
@@ -78,15 +77,6 @@ export function BioEditor({
     if (err.statusCode === 404) {
       saveFieldValueToLocalStorage()
       router.replace(redirectLoginPath)
-    } else if (err.statusCode === 422) {
-      if (err.message.startsWith('自己紹介')) {
-        setFieldError({
-          type: err.statusCode.toString(),
-          message: err.message,
-        })
-      } else {
-        openErrorSnackbar(err)
-      }
     } else {
       openErrorSnackbar(err)
     }


### PR DESCRIPTION
### Summary

<!-- Briefly describe the purpose of the pull request and the changes it introduces -->
The front-end and back-end validations for bio are completely consistent. Therefore, the code to display  validation error messages from the back-end is unnecessary. To simplify, unnecessary code will be removed.

### Changes

<!-- Explain the specific changes or additions made -->
- Removed the code from `handleHttpError` in `BioEditor` to display validation error messages returned from the back-end.

### Testing

<!-- Describe how the changes were tested to ensure they work as expected -->
As shown in the following image, it was confirmed that the error message for exceeding the character limit is displayed correctly.
![screen-shot-311](https://github.com/user-attachments/assets/794d0d0c-dc1a-49e9-b034-25da8d449a83)

### Related Issues (Optional)

<!-- Mention any related issue numbers (excluding task management issue) -->
N/A

### Notes (Optional)

<!-- Include any additional information or considerations -->
No additional information or considerations at this time.
