### PR TITLE
fix: fix Zod validation error on the homepage

### DIFF
--- a/src/app/_components/login-link/validate-token.api.ts
+++ b/src/app/_components/login-link/validate-token.api.ts
@@ -2,7 +2,7 @@
 
 import camelcaseKeys, { CamelCaseKeys } from 'camelcase-keys'
 import { z } from 'zod'
-import { validateTokenDataSchema } from '@/schemas/response/validate-token-success'
+import { accountSchema } from '@/schemas/response/account'
 import { ResultObject } from '@/types/api'
 import { fetchData } from '@/utils/api/fetch-data'
 import { getBearerToken } from '@/utils/cookie/bearer-token'
@@ -10,7 +10,7 @@ import { createErrorObject } from '@/utils/error/create-error-object'
 import { getRequestId } from '@/utils/request-id/get-request-id'
 import { validateData } from '@/utils/validation/validate-data'
 
-type Data = CamelCaseKeys<z.infer<typeof validateTokenDataSchema>, true>
+type Data = CamelCaseKeys<z.infer<typeof accountSchema>, true>
 
 export async function validateToken() {
   const fetchDataResult = await fetchData(
@@ -32,7 +32,7 @@ export async function validateToken() {
     const requestId = getRequestId(headers)
     const validateDataResult = validateData({
       requestId,
-      dataSchema: validateTokenDataSchema,
+      dataSchema: accountSchema,
       data,
     })
 


### PR DESCRIPTION
### Summary

<!-- Briefly describe the purpose of the pull request and the changes it introduces -->

Due to backend changes, a Zod validation error is occurring in the process of controlling the destination of the login link on the homepage.

<details>
<summary>Error details</summary>

```text
FATAL (tascon-frontend/18): Validation failed due to schema mismatch.
    err: {
      "type": "ValidationError",
      "message": "Validation failed due to schema mismatch.: [\n  {\n    \"code\": \"invalid_literal\",\n    \"expected\": true,\n    \"path\": [\n      \"success\"\n    ],\n    \"message\": \"Invalid literal value, expected true\"\n  },\n  {\n    \"code\": \"invalid_type\",\n    \"expected\": \"object\",\n    \"received\": \"undefined\",\n    \"path\": [\n      \"data\"\n    ],\n    \"message\": \"Required\"\n  }\n]",
      "stack":
          ValidationError: Validation failed due to schema mismatch.
              at createValidationError (webpack-internal:///(action-browser)/./src/utils/error/create-validation-error.ts:10:29)
              at validateData (webpack-internal:///(action-browser)/./src/utils/validation/validate-data.ts:17:105)
              at validateToken (webpack-internal:///(action-browser)/./src/app/_components/login-link/validate-token.api.ts:38:113)
              at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
              at async /home/node/tascon-frontend/node_modules/next/dist/compiled/next-server/app-page.runtime.dev.js:39:418
              at async rk (/home/node/tascon-frontend/node_modules/next/dist/compiled/next-server/app-page.runtime.dev.js:38:8148)
              at async r3 (/home/node/tascon-frontend/node_modules/next/dist/compiled/next-server/app-page.runtime.dev.js:41:1256)
              at async doRender (/home/node/tascon-frontend/node_modules/next/dist/server/base-server.js:1413:30)
              at async cacheEntry.responseCache.get.routeKind (/home/node/tascon-frontend/node_modules/next/dist/server/base-server.js:1574:28)
              at async DevServer.renderToResponseWithComponentsImpl (/home/node/tascon-frontend/node_modules/next/dist/server/base-server.js:1482:28)
              at async DevServer.renderPageComponent (/home/node/tascon-frontend/node_modules/next/dist/server/base-server.js:1908:24)
              at async DevServer.renderToResponseImpl (/home/node/tascon-frontend/node_modules/next/dist/server/base-server.js:1946:32)
              at async DevServer.pipeImpl (/home/node/tascon-frontend/node_modules/next/dist/server/base-server.js:921:25)
              at async NextNodeServer.handleCatchallRenderRequest (/home/node/tascon-frontend/node_modules/next/dist/server/next-server.js:272:17)
              at async DevServer.handleRequestImpl (/home/node/tascon-frontend/node_modules/next/dist/server/base-server.js:817:17)
              at async /home/node/tascon-frontend/node_modules/next/dist/server/dev/next-dev-server.js:339:20
              at async Span.traceAsyncFn (/home/node/tascon-frontend/node_modules/next/dist/trace/trace.js:154:20)
              at async DevServer.handleRequest (/home/node/tascon-frontend/node_modules/next/dist/server/dev/next-dev-server.js:336:24)
              at async invokeRender (/home/node/tascon-frontend/node_modules/next/dist/server/lib/router-server.js:173:21)
              at async handleRequest (/home/node/tascon-frontend/node_modules/next/dist/server/lib/router-server.js:350:24)
              at async requestHandlerImpl (/home/node/tascon-frontend/node_modules/next/dist/server/lib/router-server.js:374:13)
              at async Server.requestListener (/home/node/tascon-frontend/node_modules/next/dist/server/lib/start-server.js:141:13)
          caused by: ZodError: [
            {
              "code": "invalid_literal",
              "expected": true,
              "path": [
                "success"
              ],
              "message": "Invalid literal value, expected true"
            },
            {
              "code": "invalid_type",
              "expected": "object",
              "received": "undefined",
              "path": [
                "data"
              ],
              "message": "Required"
            }
          ]
              at get error (webpack-internal:///(action-browser)/./node_modules/zod/lib/index.mjs:699:31)
              at ZodObject.parse (webpack-internal:///(action-browser)/./node_modules/zod/lib/index.mjs:775:22)
              at validateValue (webpack-internal:///(action-browser)/./src/utils/type-guard/validate-value.ts:6:12)
              at validateData (webpack-internal:///(action-browser)/./src/utils/validation/validate-data.ts:13:82)
              at validateToken (webpack-internal:///(action-browser)/./src/app/_components/login-link/validate-token.api.ts:38:113)
              at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
              at async /home/node/tascon-frontend/node_modules/next/dist/compiled/next-server/app-page.runtime.dev.js:39:418
              at async rk (/home/node/tascon-frontend/node_modules/next/dist/compiled/next-server/app-page.runtime.dev.js:38:8148)
              at async r3 (/home/node/tascon-frontend/node_modules/next/dist/compiled/next-server/app-page.runtime.dev.js:41:1256)
              at async doRender (/home/node/tascon-frontend/node_modules/next/dist/server/base-server.js:1413:30)
              at async cacheEntry.responseCache.get.routeKind (/home/node/tascon-frontend/node_modules/next/dist/server/base-server.js:1574:28)
              at async DevServer.renderToResponseWithComponentsImpl (/home/node/tascon-frontend/node_modules/next/dist/server/base-server.js:1482:28)
              at async DevServer.renderPageComponent (/home/node/tascon-frontend/node_modules/next/dist/server/base-server.js:1908:24)
              at async DevServer.renderToResponseImpl (/home/node/tascon-frontend/node_modules/next/dist/server/base-server.js:1946:32)
              at async DevServer.pipeImpl (/home/node/tascon-frontend/node_modules/next/dist/server/base-server.js:921:25)
              at async NextNodeServer.handleCatchallRenderRequest (/home/node/tascon-frontend/node_modules/next/dist/server/next-server.js:272:17)
              at async DevServer.handleRequestImpl (/home/node/tascon-frontend/node_modules/next/dist/server/base-server.js:817:17)
              at async /home/node/tascon-frontend/node_modules/next/dist/server/dev/next-dev-server.js:339:20
              at async Span.traceAsyncFn (/home/node/tascon-frontend/node_modules/next/dist/trace/trace.js:154:20)
              at async DevServer.handleRequest (/home/node/tascon-frontend/node_modules/next/dist/server/dev/next-dev-server.js:336:24)
              at async invokeRender (/home/node/tascon-frontend/node_modules/next/dist/server/lib/router-server.js:173:21)
              at async handleRequest (/home/node/tascon-frontend/node_modules/next/dist/server/lib/router-server.js:350:24)
              at async requestHandlerImpl (/home/node/tascon-frontend/node_modules/next/dist/server/lib/router-server.js:374:13)
              at async Server.requestListener (/home/node/tascon-frontend/node_modules/next/dist/server/lib/start-server.js:141:13)
      "name": "ValidationError",
      "requestId": "57dde380-0e04-473e-bb92-805961c2c4f7"
    }
```

</details>

To fix this, the Zod schema for response validation will be modified.

Clicking the login link while authenticated will now redirect to `/tasks`.

### Changes

<!-- Explain the specific changes or additions made -->

- The response validation schema for `validateToken` has been changed from `validateTokenDataSchema` to `accountSchema`.
  This change will resolve the Zod validation error that occurs when opening the homepage.

### Testing

<!-- Describe how the changes were tested to ensure they work as expected -->

As shown in the following image, it was confirmed that clicking the login link while authenticated redirects to `/tasks`.
![screen-recording-35](https://github.com/user-attachments/assets/dba54397-62d6-4eb2-a7b1-703c6392cea5)

### Related Issues (Optional)

<!-- Mention any related issue numbers (excluding task management issue) -->

N/A

### Notes (Optional)

<!-- Include any additional information or considerations -->

No additional information or considerations at this time.
