### PR TITLE
fix: fix cursor on button hover

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -109,7 +109,12 @@ module.exports = {
     },
   },
   plugins: [
-    plugin(function ({ addComponents, addUtilities }) {
+    plugin(function ({ addBase, addComponents, addUtilities }) {
+      addBase({
+        'button:not(:disabled), [role="button"]:not(:disabled)': {
+          cursor: 'pointer',
+        },
+      })
       addComponents({
         '.skeleton': {
           '@apply animate-pulse bg-gray-300': {},


### PR DESCRIPTION
### Summary

TailwindCSS update resulted in the cursor not changing to a pointer when hovering over buttons.
To fix this, a declaration has been added to `tailwindcss.config.js` to set the button's cursor to `pointer`.

![screen-shot-318](https://github.com/user-attachments/assets/98651590-3c11-495c-aff7-be66a90178fe)

### Changes

- Added an `addBase()` declaration to `tailwindcss.config.js`, configuring the `button` cursor to be set to `pointer`.
  With this change, the cursor will now become a pointer when hovering over buttons.

### Testing

Confirmed that the cursor turns to a pointer when hovering over each button.

![screen-shot-319](https://github.com/user-attachments/assets/e7eedd43-c9d9-4193-aafa-05c43123fd98)

### Related Issues (Optional)

N/A

### Notes (Optional)

The following link was used as a reference:

- [TailwindCSS Upgrade guide](https://tailwindcss.com/docs/upgrade-guide#buttons-use-the-default-cursor)
