### PR TITLE
fix: fix the error that occurs during password reset

### DIFF
--- a/src/app/(auth)/password/reset/_components/reset-password-form/reset-password.api.ts
+++ b/src/app/(auth)/password/reset/_components/reset-password-form/reset-password.api.ts
@@ -4,7 +4,7 @@ import camelcaseKeys from 'camelcase-keys'
 import { cookies } from 'next/headers'
 import snakecaseKeys from 'snakecase-keys'
 import { z } from 'zod'
-import { authSchema } from '@/schemas/response/auth'
+import { accountSchema } from '@/schemas/response/account'
 import { ResultObject } from '@/types/api'
 import { fetchData } from '@/utils/api/fetch-data'
 import { getBearerToken, setBearerToken } from '@/utils/cookie/bearer-token'
@@ -17,13 +17,7 @@ type Params = {
   password: string
 }
 
-const dataSchema = z.object({
-  success: z.literal(true),
-  data: authSchema.omit({ avatar_url: true }),
-  message: z.string(),
-})
-
-type Data = CamelCaseKeys<z.infer<typeof dataSchema>, true>
+type Data = CamelCaseKeys<z.infer<typeof accountSchema>, true>
 
 export async function resetPassword(bodyData: Params) {
   const fetchDataResult = await fetchData(
@@ -50,7 +44,11 @@ export async function resetPassword(bodyData: Params) {
     const { headers, data } = fetchDataResult
     const requestId = getRequestId(headers)
 
-    const validateDataResult = validateData({ requestId, dataSchema, data })
+    const validateDataResult = validateData({
+      requestId,
+      dataSchema: accountSchema,
+      data,
+    })
     if (validateDataResult instanceof Error) {
       resultObject = createErrorObject(validateDataResult)
     } else {


### PR DESCRIPTION
### Summary

<!-- Briefly describe the purpose of the pull request and the changes it introduces -->
An error occurs during password reset as shown in the following image.
![screen-shot-324](https://github.com/user-attachments/assets/2a960a13-8068-4d10-bd49-af7f149128d5)

This is due to a Zod validation error caused by a backend change.
To fix this, the Zod schema for validating the password reset response is modified.

### Changes

<!-- Explain the specific changes or additions made -->

- Changed the Zod schema for validating the response of `resetPassword()` to `accountSchema`
  This change resolve the error during password reset.

### Testing

<!-- Describe how the changes were tested to ensure they work as expected -->

As shown in the following image, it was confirmed that the password reset process can be executed successfully.
![screen-recording-41](https://github.com/user-attachments/assets/bd4149b6-5ef1-42b2-b7db-931099800488)

### Related Issues (Optional)

<!-- Mention any related issue numbers (excluding task management issue) -->

N/A

### Notes (Optional)

<!-- Include any additional information or considerations -->

No additional information or considerations at this time.
