### PR TITLE
build: enable Turbopack for dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,4 @@ WORKDIR /home/${USER_NAME}/${PROJECT_NAME}
 
 EXPOSE 3000
 
-CMD ["bash", "-c", "node -r ./.pnp.cjs $(yarn bin next) dev"]
+CMD ["bash", "-c", "node -r ./.pnp.cjs $(yarn bin next) dev --turbopack"]

--- a/compose.yml
+++ b/compose.yml
@@ -12,4 +12,4 @@ services:
     ports:
       - ${FRONTEND_PORT:-3000}:3000
       - ${STORYBOOK_PORT:-6006}:6006
-    command: bash -c "node node_modules/.bin/next dev"
+    command: bash -c "node node_modules/.bin/next dev --turbopack"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --turbopack",
     "debug": "NODE_OPTIONS='--inspect=0.0.0.0 -r ./.pnp.cjs' next dev",
     "build": "ANALYZE=true next build",
     "start": "next start",

--- a/src/app/(main)/_components/main-header/index.tsx
+++ b/src/app/(main)/_components/main-header/index.tsx
@@ -1,7 +1,7 @@
 import Image from 'next/image'
 import Link from 'next/link'
-import smallLogo from '/public/logos/logo-small.png'
 import { Suspense } from 'react'
+import smallLogo from 'public/logos/logo-small.png'
 import { AccountLink } from './account-avatar-link/account-link'
 import { HeaderAvatar, LoadingHeaderAvatar } from './header-avatar'
 import { NavLinks } from './nav-links'


### PR DESCRIPTION
### Summary

<!-- Briefly describe the purpose of the pull request and the changes it introduces -->

Activate Turbopack to improve development efficiency.
Since `build` is still in alpha, only `dev`, which is already stable, is enabled.

### Changes

<!-- Explain the specific changes or additions made -->

- Enabled turbopack for `dev` (33544479125d06fdd423626e84c47cbdddfd7252)
	Changed `next dev` to `next dev --turbopack`.

- Fixed module not found error (695440c3c8fa7b020ccbcd2ea6f4b0feba62d614)
	The following error that occurred when activating Turbopack has been fixed.
	![screen-shot-329](https://github.com/user-attachments/assets/b16d5f84-2c66-44e7-88f1-1741e6ff2e39)


### Testing

<!-- Describe how the changes were tested to ensure they work as expected -->
I have confirmed that Turbopack is enabled in the `dev` environment as shown in the following image.
![screen-shot-329](https://github.com/user-attachments/assets/11e0c68d-0ce9-444b-9944-b8db331957c4)


### Related Issues (Optional)

<!-- Mention any related issue numbers (excluding task management issues) -->
N/A

### Notes (Optional)

<!-- Include any additional information or considerations -->
The following page was used as a reference.

- [API Reference: Turbopack | Next.js](https://nextjs.org/docs/app/api-reference/turbopack#getting-started)

- [next dev --turbopack does not support using @next/bundle-analyzer - throws warning | vercel/next.js](https://is.gd/QCk3Tw)
	![screen-shot-328](https://github.com/user-attachments/assets/bcb1e2d4-21d1-47b4-956c-bedf11aa73e6)
