### PR TITLE
chore: replace depandabot reviewers with CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @P-manBrown

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,8 +20,6 @@ updates:
       interval: 'daily'
       time: '03:00'
       timezone: 'Asia/Tokyo'
-    reviewers:
-      - 'P-manBrown'
     commit-message:
       prefix: 'build'
     target-branch: 'main'


### PR DESCRIPTION
### Summary

<!-- Briefly describe the purpose of the pull request and the changes it introduces -->

Dependabot's `reviewrs` has been deprecated.
In response, `CODEOWNERS` will be created.

### Changes

<!-- Explain the specific changes or additions made -->

- Removed `reviewers` from `dependabot.yml`
- Added `CODEOWNERS`

### Testing

<!-- Describe how the changes were tested to ensure they work as expected -->

None

### Related Issues (Optional)

<!-- Mention any related issue numbers (excluding task management issue) -->

N/A

### Notes (Optional)

<!-- Include any additional information or considerations -->

Refer to the following page.

- [Dependabot reviewers configuration option being replaced by code owners - GitHub Changelog](https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/)
