### PR TITLE
fix: display success message for password reset email sent on the account page

### DIFF
--- a/src/components/pages/account-page/current-user-info/current-user-change-password-form-show-button/change-password-form-show-button/use-change-password-form-show-button.tsx
+++ b/src/components/pages/account-page/current-user-info/current-user-change-password-form-show-button/change-password-form-show-button/use-change-password-form-show-button.tsx
@@ -70,7 +70,7 @@ export function useChangePasswordFormShowButton({ email }: Params) {
     } else {
       openSnackbar({
         severity: 'success',
-        message: result.message,
+        message: `'${email}' にパスワードリセットの案内を送信しました。`,
       })
     }
     setIsSending(false)


### PR DESCRIPTION
### Summary

<!-- Briefly describe the purpose of the pull request and the changes it introduces -->
Due to backend changes, the success message for sending a password reset email is not displayed correctly on the account page password change form.
![screen-recording-43](https://github.com/user-attachments/assets/71a64b8f-74ad-41cd-9dc9-a285b6cb25dc)

To resolve this, the `handleResetPasswordButtonClick` in `useChangePasswordFormShowButton` is modified.

### Changes

<!-- Explain the specific changes or additions made -->
- The `message` in `openSnackbar` of `handleResetPasswordButtonClick` in `useChangePasswordFormShowButton` is corrected to pass the appropriate value.
This change ensures that a success message is displayed on the account page when a password reset email is sent.

### Testing

<!-- Describe how the changes were tested to ensure they work as expected -->
As shown in the following image, it was confirmed that a success message is displayed when a password reset email is sent.
![screen-recording-46](https://github.com/user-attachments/assets/4f2f7adb-ace4-4e7e-ae58-9b6552d407d2)

### Related Issues (Optional)

<!-- Mention any related issue numbers (excluding task management issue) -->
N/A

### Notes (Optional)

<!-- Include any additional information or considerations -->
No additional information or considerations at this time.
