### PR TITLE
fix: prevent outdated information from being displayed after name changes

### DIFF
--- a/src/components/editable-text/index.tsx
+++ b/src/components/editable-text/index.tsx
@@ -99,7 +99,7 @@ export function EditableText({
         >
           {children}
           <button
-            className={`absolute left-0 top-0 h-full w-full rounded-sm duration-200 has-[>span]:hover:bg-black/10 ${
+            className={`absolute top-0 left-0 h-full w-full rounded-sm duration-200 has-[>span]:hover:bg-black/10 ${
               isTextSelected || isDraggingInside ? 'pointer-events-none' : ''
             }`}
             onClick={openEditor}

--- a/src/components/editable-text/use-editable-text.tsx
+++ b/src/components/editable-text/use-editable-text.tsx
@@ -30,7 +30,7 @@ export function useEditableText<T extends FieldValues>({
     getValues,
     setValue,
     setError,
-    formState: { isDirty, isSubmitting, errors },
+    formState: { isDirty, isValid, isSubmitting, errors },
   } = useForm({
     mode: 'onChange',
     shouldFocusError: false,
@@ -88,10 +88,12 @@ export function useEditableText<T extends FieldValues>({
         await handleSubmit(onSubmit)()
       } else {
         removeLocalStorageValue()
+      }
+      if (isValid) {
         setIsEditorOpen(false)
       }
     },
-    [isDirty, handleSubmit, removeLocalStorageValue],
+    [isDirty, handleSubmit, removeLocalStorageValue, isValid],
   )
 
   const handleBlur: BlurHandler<T> = useCallback(
@@ -108,11 +110,13 @@ export function useEditableText<T extends FieldValues>({
             await handleSubmit(onSubmit)()
           } else {
             removeLocalStorageValue()
+          }
+          if (isValid) {
             setIsEditorOpen(false)
           }
         }
       },
-    [isDirty, handleSubmit, removeLocalStorageValue],
+    [isDirty, handleSubmit, removeLocalStorageValue, isValid],
   )
 
   const handleCancelClick = useCallback(() => {


### PR DESCRIPTION
### Summary

<!-- Briefly describe the purpose of the pull request and the changes it introduces -->
When changing the username on the account page, the old username is displayed for a moment.

![screen-recording-47](https://github.com/user-attachments/assets/5e39f528-e97c-467e-a191-5018d4e53c2c)

To fix this, `useTransition()` is added to `NameEditor()`.

### Changes

<!-- Explain the specific changes or additions made -->
- Added `useTransition()` to `NameEditor()`

### Testing

<!-- Describe how the changes were tested to ensure they work as expected -->

Tested the following range in the [test case list](https://docs.google.com/spreadsheets/d/1ESeGIE8ghgZqR0U_RbAJMcV6XgRBxjOQdq2xNooxRjo/edit?usp=sharing):

- `f-3-1` - `f-3-8`
- `f-11-1` - `f-11-4`

As shown in the following image, it was confirmed that the old username is no longer displayed when changing the username.
![screen-recording-48](https://github.com/user-attachments/assets/b25fb713-189a-4984-8d79-9853a885ccd9)

### Related Issues (Optional)

<!-- Mention any related issue numbers (excluding task management issue) -->
N/A

### Notes (Optional)

<!-- Include any additional information or considerations -->
No additional information or considerations at this time.
