### PR TITLE
fix: prevent outdated information from being displayed after avatar changes

### DIFF
--- a/src/components/pages/account-page/current-user-info/editable-avatar/avatar-editor/index.tsx
+++ b/src/components/pages/account-page/current-user-info/editable-avatar/avatar-editor/index.tsx
@@ -16,7 +16,7 @@ export function AvatarEditor({ avatarUrl, children }: Props) {
     onSubmit,
     handleXMarkClick,
     ref,
-    isSubmitting,
+    isPending,
     errors,
     inputRef,
     isDeletingAvatar,
@@ -29,16 +29,16 @@ export function AvatarEditor({ avatarUrl, children }: Props) {
         <button
           type="button"
           className={`peer clickable-avatar disabled:cursor-wait disabled:hover:brightness-100 ${
-            isSubmitting ? 'disabled:animate-pulse' : ''
+            isPending ? 'disabled:animate-pulse' : ''
           }`}
-          disabled={isSubmitting || isDeletingAvatar}
+          disabled={isPending || isDeletingAvatar}
           tabIndex={0}
           aria-label="アバター変更"
           onClick={() => inputRef.current?.click()}
         >
           {children}
         </button>
-        {avatarUrl && !isSubmitting && (
+        {avatarUrl && !isPending && (
           <IconButton
             type="button"
             className={`absolute top-0.5 right-0.5 z-10 duration-[1ms] peer-hover:visible hover:visible [@media(hover:hover)]:peer-focus-visible:visible [@media(hover:hover)]:focus-visible:visible ${


### PR DESCRIPTION
### Summary

<!-- Briefly describe the purpose of the pull request and the changes it introduces -->
When changing the avatar on the account page, the old avatar is displayed for a moment.

![screen-recording-51-2](https://github.com/user-attachments/assets/75ba718d-5288-4bde-9e61-c92bee74390d)

To fix this, `useTransition()` is added to `useAvatarEditor()`.

### Changes

<!-- Explain the specific changes or additions made -->
- Added `useTransition()` to `useAvatarEditor()`
- Use `isPending` from `useTransition` to manage loading states

### Testing

<!-- Describe how the changes were tested to ensure they work as expected -->

Tested the following range in the [test case list](https://docs.google.com/spreadsheets/d/1ESeGIE8ghgZqR0U_RbAJMcV6XgRBxjOQdq2xNooxRjo/edit?usp=sharing):

- `f-2-1` - `f-2-3`
- `f-10-1` - `f-10-2`
- `f-10-4` - `f-10-5`

As shown in the following image, it was confirmed that the old avatar is no longer displayed when changing the avatar.
![screen-recording-52](https://github.com/user-attachments/assets/6ca7ffcb-b13d-4e37-b628-5ddb17c15c83)

### Related Issues (Optional)

<!-- Mention any related issue numbers (excluding task management issue) -->
N/A

### Notes (Optional)

<!-- Include any additional information or considerations -->
No additional information or considerations at this time.
