### PR TITLE
fix: prevent outdated information from being displayed after avatar deletion

### DIFF
--- a/src/components/pages/account-page/current-user-info/editable-avatar/avatar-editor/index.tsx
+++ b/src/components/pages/account-page/current-user-info/editable-avatar/avatar-editor/index.tsx
@@ -16,10 +16,10 @@ export function AvatarEditor({ avatarUrl, children }: Props) {
     onSubmit,
     handleXMarkClick,
     ref,
-    isPending,
+    isSubmitting,
     errors,
     inputRef,
-    isDeletingAvatar,
+    isDeleting,
     registerRest,
   } = useAvatarEditor()
 
@@ -29,23 +29,23 @@ export function AvatarEditor({ avatarUrl, children }: Props) {
         <button
           type="button"
           className={`peer clickable-avatar disabled:cursor-wait disabled:hover:brightness-100 ${
-            isPending ? 'disabled:animate-pulse' : ''
+            isSubmitting ? 'disabled:animate-pulse' : ''
           }`}
-          disabled={isPending || isDeletingAvatar}
+          disabled={isSubmitting || isDeleting}
           tabIndex={0}
           aria-label="アバター変更"
           onClick={() => inputRef.current?.click()}
         >
           {children}
         </button>
-        {avatarUrl && !isPending && (
+        {avatarUrl && !isSubmitting && (
           <IconButton
             type="button"
             className={`absolute top-0.5 right-0.5 z-10 duration-[1ms] peer-hover:visible hover:visible [@media(hover:hover)]:peer-focus-visible:visible [@media(hover:hover)]:focus-visible:visible ${
-              isDeletingAvatar ? '' : '[@media(hover:hover)]:invisible'
+              isDeleting ? '' : '[@media(hover:hover)]:invisible'
             }`}
             aria-label="アバター削除"
-            status={isDeletingAvatar ? 'pending' : 'idle'}
+            status={isDeleting ? 'pending' : 'idle'}
             onClick={handleXMarkClick}
           >
             <XCircleIcon className="size-6 fill-black stroke-white" />

--- a/src/components/pages/account-page/current-user-info/editable-avatar/avatar-editor/index.tsx
+++ b/src/components/pages/account-page/current-user-info/editable-avatar/avatar-editor/index.tsx
@@ -16,7 +16,7 @@ export function AvatarEditor({ avatarUrl, children }: Props) {
     onSubmit,
     handleXMarkClick,
     ref,
-    isSubmitting,
+    isPending,
     errors,
     inputRef,
     isDeletingAvatar,
@@ -29,16 +29,16 @@ export function AvatarEditor({ avatarUrl, children }: Props) {
         <button
           type="button"
           className={`peer clickable-avatar disabled:cursor-wait disabled:hover:brightness-100 ${
-            isSubmitting ? 'disabled:animate-pulse' : ''
+            isPending ? 'disabled:animate-pulse' : ''
           }`}
-          disabled={isSubmitting || isDeletingAvatar}
+          disabled={isPending || isDeletingAvatar}
           tabIndex={0}
           aria-label="アバター変更"
           onClick={() => inputRef.current?.click()}
         >
           {children}
         </button>
-        {avatarUrl && !isSubmitting && (
+        {avatarUrl && !isPending && (
           <IconButton
             type="button"
             className={`absolute top-0.5 right-0.5 z-10 duration-[1ms] peer-hover:visible hover:visible [@media(hover:hover)]:peer-focus-visible:visible [@media(hover:hover)]:focus-visible:visible ${


### PR DESCRIPTION
### Summary

<!-- Briefly describe the purpose of the pull request and the changes it introduces -->
When deleting an avatar on the account page, the old avatar is displayed for a while even after `isDeleting` becomes `false`.

![screen-recording-54](https://github.com/user-attachments/assets/328a6300-c07d-49db-b89b-80d9026e332b)

To fix this, `useTransition()` is added to `useAvatarEditor()`.

### Changes

<!-- Explain the specific changes or additions made -->
- Added `useTransition()` to `useAvatarEditor()`
- Use `isDeleting` from `useTransition()` to manage deleting states

### Testing

<!-- Describe how the changes were tested to ensure they work as expected -->

Tested the following range in the [test case list](https://docs.google.com/spreadsheets/d/1ESeGIE8ghgZqR0U_RbAJMcV6XgRBxjOQdq2xNooxRjo/edit?usp=sharing):

- `f-2-4`

As shown in the following image, it was confirmed that the old avatar is no longer displayed when deleting the avatar.
![screen-recording-55](https://github.com/user-attachments/assets/c6c29c14-fb2e-4e26-aa2f-52e467738905)

### Related Issues (Optional)

<!-- Mention any related issue numbers (excluding task management issue) -->
N/A

### Notes (Optional)

<!-- Include any additional information or considerations -->
No additional information or considerations at this time.
