### PR TITLE
fix: prevent outdated information from being displayed after private mode changes

### DIFF
--- a/src/components/pages/account-page/current-user-info/private-mode-switch/private-mode-checkbox/index.tsx
+++ b/src/components/pages/account-page/current-user-info/private-mode-switch/private-mode-checkbox/index.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useRouter, useSearchParams } from 'next/navigation'
-import { useState } from 'react'
+import { useTransition } from 'react'
 import { useErrorSnackbar } from '@/app/_components/snackbars/snackbar/use-error-snackbar'
 import { Checkbox } from '@/components/form-controls/checkbox'
 import { ErrorObject } from '@/types/error'
@@ -25,7 +25,7 @@ export function PrivateModeCheckbox({
   const router = useRouter()
   const searchParams = useSearchParams()
   const redirectLoginPath = useRedirectLoginPath({ searchParams })
-  const [isChangingIsPrivate, setIsChangingIsPrivate] = useState(false)
+  const [isPending, startTransition] = useTransition()
 
   const handleKeyDown = (ev: React.KeyboardEvent<HTMLLabelElement>) => {
     if ((ev.key === 'Enter' || ev.key === ' ') && !ev.metaKey) {
@@ -43,22 +43,22 @@ export function PrivateModeCheckbox({
   }
 
   const handleChange = async (ev: React.ChangeEvent<HTMLInputElement>) => {
-    setIsChangingIsPrivate(true)
-    const result = await changeIsPrivate({ isPrivate: ev.target.checked })
-    if (result.status === 'error') {
-      if (result.name === 'HttpError') {
-        handleHttpError(result)
-      } else {
-        openErrorSnackbar(result)
+    startTransition(async () => {
+      const result = await changeIsPrivate({ isPrivate: ev.target.checked })
+      if (result.status === 'error') {
+        if (result.name === 'HttpError') {
+          handleHttpError(result)
+        } else {
+          openErrorSnackbar(result)
+        }
       }
-    }
-    setIsChangingIsPrivate(false)
+    })
   }
 
   return (
     <Checkbox
       checked={isPrivate}
-      disabled={isChangingIsPrivate}
+      disabled={isPending}
       toggleIcon={toggleIcon}
       description={description}
       onKeyDown={handleKeyDown}


### PR DESCRIPTION
### Summary

When toggling the private mode on the account page, even after the loading state ends, outdated information continues to be displayed for a short period.

![screen-recording-56](https://github.com/user-attachments/assets/e802b118-9bcf-43dd-b14b-99be5dc22e8d)

To fix this, `useTransition()` was added to `PrivateModeCheckbox()`.

### Changes

- Added `useTransition()` to `PrivateModeCheckbox()`

### Testing

Tested the following range in the [test case list](https://docs.google.com/spreadsheets/d/1ESeGIE8ghgZqR0U_RbAJMcV6XgRBxjOQdq2xNooxRjo/edit?usp=sharing):

- `f-6-1`

As shown in the image below, it has been confirmed that outdated information is no longer displayed after processing when switching private mode.
![screen-recording-57](https://github.com/user-attachments/assets/d33f7257-d296-411a-ac63-0e33fa661001)

### Related Issues (Optional)

N/A

### Notes (Optional)

No additional information or considerations at this time.
