### PR TITLE
fix: prevent main content wrapping on sidebar toggle in mobile view

### DIFF
--- a/src/app/(main)/users/layout.tsx
+++ b/src/app/(main)/users/layout.tsx
@@ -8,13 +8,13 @@ type Props = {
 
 export default async function UsersLayout({ children, modal }: Props) {
   return (
-    <div className="flex h-full w-full">
-      <div className="flex-none">
-        <Suspense fallback={null}>
-          <UsersSidebar />
-        </Suspense>
-      </div>
-      <main className="flex-grow overflow-auto p-4">{children}</main>
+    <div className="flex h-full">
+      <Suspense fallback={null}>
+        <UsersSidebar />
+      </Suspense>
+      <main className="flex-grow overflow-auto p-4 max-md:min-w-dvw">
+        {children}
+      </main>
       {modal}
     </div>
   )


### PR DESCRIPTION
### Summary

Fix main content wrapping issue that occurs when toggling the sidebar in mobile view. The main content area was not maintaining proper width constraints, causing layout shifts and content wrapping on medium and smaller screen sizes.

### Changes

- Add `max-md:min-w-dvw` class to the main element in `src/app/(main)/users/layout.tsx`
- Remove unnecessary wrapper div and simplify layout structure
- Ensure main content maintains full viewport width on mobile screens when sidebar toggles

### Testing

- Tested sidebar toggle functionality on mobile devices (viewport width < 768px)
- Verified content maintains proper width and positioning during sidebar open/close transitions
- Confirmed no layout shifts or content wrapping occurs on medium and smaller screens
- Desktop functionality remains unaffected

### Related Issues

N/A

### Notes

This fix specifically targets mobile viewport behavior using Tailwind's `max-md:` responsive prefix combined with `min-w-dvw` (minimum width: dynamic viewport width) to ensure the main content area always spans the full viewport width on smaller screens, preventing unwanted wrapping when the sidebar state changes.
