### PR TITLE
fix: adjust padding in users layout main content

### DIFF
--- a/src/app/(main)/users/layout.tsx
+++ b/src/app/(main)/users/layout.tsx
@@ -12,7 +12,7 @@ export default async function UsersLayout({ children, modal }: Props) {
       <Suspense fallback={null}>
         <UsersSidebar />
       </Suspense>
-      <main className="flex-grow overflow-auto p-4 max-md:min-w-dvw">
+      <main className="flex-grow overflow-auto p-5 max-md:min-w-dvw md:px-10 md:py-5">
         {children}
       </main>
       {modal}


### PR DESCRIPTION
### Summary

Improve spacing and visual layout of the users layout main content area by adjusting padding values for both mobile
  and desktop viewports. The previous padding was insufficient for optimal visual spacing, particularly on mobile
devices.

### Changes

- Increase base padding from `p-4` to `p-5` for improved mobile spacing (from 16px to 20px)
- Add responsive desktop padding `md:px-10 md:py-5` for better desktop experience (40px horizontal, 20px vertical)
- Maintain existing mobile-first responsive behavior and `max-md:min-w-dvw` class for sidebar compatibility

### Testing

- Tested layout spacing on mobile devices (viewport width < 768px) with increased base padding
- Verified desktop layout with enhanced horizontal padding (md:px-10) for better content spacing
- Confirmed compatibility with existing sidebar toggle functionality

### Related Issues

N/A

### Notes

This change implements a mobile-first responsive padding strategy:
- Mobile (default): `p-5` (20px all sides)
- Desktop (md+): `px-10 py-5` (40px horizontal, 20px vertical)

The enhanced padding improves content readability and provides better visual hierarchy while maintaining responsive
  behavior with the existing sidebar system.
