### PR TITLE
fix: apply rounded corners to default avatar background

### DIFF
--- a/src/components/avatars/avatar/index.tsx
+++ b/src/components/avatars/avatar/index.tsx
@@ -13,7 +13,7 @@ const shapeClasses = 'rounded-full'
 
 export function Avatar({ size, name, avatarUrl, priority = false }: Props) {
   return avatarUrl == null ? (
-    <span className="bg-gray-300">
+    <span className={`bg-gray-300 ${shapeClasses}`}>
       <DefaultAvatar
         size={size}
         name={name}


### PR DESCRIPTION
### Summary

Fix visual inconsistency in default avatar component where the background span element had a different shape than the default avatar content itself. The background was displaying as a square while the default avatar content was circular, creating a visual mismatch.

![before-after-572](https://github.com/user-attachments/assets/815ba2f2-8d09-41d3-9c57-a75812f6dbf8)

### Changes

- Apply `shapeClasses` (rounded-full) to the background span element in `src/components/avatars/avatar/index.tsx`
- Ensure the background shape matches the circular default avatar content
- Maintain existing functionality while fixing the shape inconsistency between background and content

### Testing

- Tested default avatar display (when `avatarUrl` is null) to verify background and content have matching circular
shapes
- Confirmed the background span now properly displays with rounded-full styling
- Cross-browser testing performed to ensure rounded corners render correctly on background elements

### Related Issues

Closes: #504

### Notes

No additional information or considerations at this time.
