### PR TITLE
fix: return parsed data from validateData function

### DIFF
--- a/src/utils/type-guard/validate-value.ts
+++ b/src/utils/type-guard/validate-value.ts
@@ -2,7 +2,7 @@ import type z from 'zod'
 
 export function validateValue<T extends z.ZodTypeAny>(
   schema: T,
-  value: unknown
+  value: unknown,
 ): asserts value is z.infer<T> {
   schema.parse(value)
 }

--- a/src/utils/validation/validate-data.ts
+++ b/src/utils/validation/validate-data.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod'
 import { createValidationError } from '../error/create-validation-error'
 import { ValidationError } from '../error/custom/validation-error'
-import { validateValue } from '../type-guard/validate-value'
 
 type Params<T> = {
   requestId: string
@@ -15,8 +14,8 @@ export function validateData<T extends z.ZodTypeAny>({
   data,
 }: Params<T>): z.infer<T> | ValidationError {
   try {
-    validateValue(dataSchema, data)
-    return data
+    const parsedData = dataSchema.parse(data)
+    return parsedData
   } catch (err) {
     if (err instanceof z.ZodError) {
       return createValidationError(requestId, err)


### PR DESCRIPTION
### Summary

Fix the validateData function to properly return the parsed and transformed data from Zod schema validation instead of returning the original input data. This ensures type safety and proper data transformation according to schema definitions.

### Changes

- Update `validateData` function in `src/utils/validation/validate-data.ts` to return `dataSchema.parse(data)` result
- Remove dependency on `validateValue` utility function within `validateData`
- Maintain proper error handling for validation failures
- Fix trailing comma formatting in `src/utils/type-guard/validate-value.ts`

### Testing

- Verified that validateData now returns properly typed and transformed data
- Confirmed error handling continues to work as expected for invalid data
- Tested that the returned data matches the Zod schema's inferred TypeScript types
- Ensured validateValue utility remains available for other use cases

### Related Issues

N/A

### Notes

No additional information or considerations at this time.
