### PR TITLE
feat: add loading page component for contacts page

### DIFF
--- a/src/app/(main)/users/contacts/loading.tsx
+++ b/src/app/(main)/users/contacts/loading.tsx
@@ -1,0 +1,5 @@
+import { LoadingPage } from '@/components/pages/loading-page'
+
+export default function Loading() {
+  return <LoadingPage pageTitle="登録しているユーザー一覧" />
+}

--- a/src/components/pages/loading-page/index.tsx
+++ b/src/components/pages/loading-page/index.tsx
@@ -1,0 +1,39 @@
+const animationSquares = [
+  { color: 'bg-ctnr-blue', position: '[--end-x:0px] [--end-y:-32px]' },
+  { color: 'bg-ctnr-green', position: '[--end-x:32px] [--end-y:-32px]' },
+  { color: 'bg-ctnr-yellow', position: '[--end-x:32px] [--end-y:0px]' },
+  { color: 'bg-ctnr-purple', position: '[--end-x:32px] [--end-y:32px]' },
+  { color: 'bg-ctnr-red', position: '[--end-x:0px] [--end-y:32px]' },
+  { color: 'bg-ctnr-gray', position: '[--end-x:-32px] [--end-y:32px]' },
+  { color: 'bg-ctnr-pink', position: '[--end-x:-32px] [--end-y:0px]' },
+  { color: 'bg-ctnr-orange', position: '[--end-x:-32px] [--end-y:-32px]' },
+]
+
+type Props = {
+  pageTitle: string
+}
+
+export function LoadingPage({ pageTitle }: Props) {
+  return (
+    <div className="animate-fade-in-delayed bg-theme relative flex h-full items-center justify-center rounded-xl">
+      <div className="flex flex-col items-center gap-y-6">
+        <div className="relative h-32 w-32">
+          {animationSquares.map((square, i) => (
+            <div
+              key={i}
+              className={`animate-expand-collapse absolute top-[calc(50%-12px)] left-[calc(50%-12px)] size-5 rounded-xs ${square.color} ${square.position}`}
+            />
+          ))}
+        </div>
+        <div className="space-y-3 text-center">
+          <p className="text-lg leading-tight font-semibold text-gray-700">
+            {pageTitle}を表示中...
+          </p>
+          <p className="animate-pulse text-gray-500 sm:text-sm">
+            しばらくお待ちください
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -29,6 +29,8 @@ module.exports = {
         'ctnr-yellow': '#7E611F',
         'ctnr-purple': '#5D355B',
         'ctnr-red': '#B1624D',
+        'ctnr-gray': '#6F747E',
+        'ctnr-pink': '#F2367E',
       },
       animation: {
         'scale-in-center':
@@ -45,6 +47,8 @@ module.exports = {
           'slide-out-bottom 0.2s cubic-bezier(0.550, 0.085, 0.680, 0.530) both',
         'slide-in-left':
           'slide-in-left 0.2s cubic-bezier(0.250, 0.460, 0.450, 0.940) both',
+        'fade-in-delayed': 'fade-in 0.2s ease-in-out 0.1s both',
+        'expand-collapse': 'expand-collapse 2s ease-in-out infinite both',
       },
       keyframes: {
         'scale-in-center': {
@@ -115,6 +119,28 @@ module.exports = {
           to: {
             transform: 'translateX(0)',
             opacity: '1',
+          },
+        },
+        'fade-in': {
+          '0%': {
+            opacity: '0',
+          },
+          to: {
+            opacity: '1',
+          },
+        },
+        'expand-collapse': {
+          '0%, 100%': {
+            transform: 'translate(0px, 0px)',
+            'box-shadow': '0 0px 0px 0 rgb(0 0 0 / 0)',
+          },
+          '22.5%, 77.5%': {
+            transform: 'translate(0px, 0px)',
+            'box-shadow': '0 3px 6px 0 rgb(0 0 0 / 0.025)',
+          },
+          '45%, 55%': {
+            transform: 'translate(var(--end-x), var(--end-y))',
+            'box-shadow': '0 3px 6px 0 rgb(0 0 0 / 0.2)',
           },
         },
       },


### PR DESCRIPTION
### Summary

Add a reusable LoadingPage component with animated loading effects for improved user experience during page transitions. The component features an animated square pattern with fade-in effects and is integrated with Next.js loading.tsx for the contacts page route.

![screen-recording-82](https://github.com/user-attachments/assets/a5d9e14f-7258-49ff-bbe8-de7909b13546)

### Changes

- Create LoadingPage component with 8 colored animated squares in `src/components/pages/loading-page/index.tsx`
- Add custom Tailwind animations: `fade-in-delayed` and `expand-collapse`
- Add new theme colors: `ctnr-gray` and `ctnr-pink` to Tailwind configuration
- Implement loading.tsx for `/users/contacts` route with Japanese page title
- Add CSS custom properties support for dynamic positioning of animated elements

### Testing

- Verified loading component displays correctly with smooth animations
- Tested fade-in delay timing and expand-collapse animation loop
- Validated Next.js loading.tsx integration shows during page transitions
- Tested responsive behavior and visual consistency across device sizes

### Related Issues

N/A

### Notes

No additional information or considerations at this time.
