### PR TITLE
fix: add ScrollAnchor workaround for Next.js 15 scroll-to-top issue

### DIFF
--- a/src/app/(main)/users/contacts/page.tsx
+++ b/src/app/(main)/users/contacts/page.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from 'react'
+import { ScrollAnchor } from '@/components/scroll-anchor'
 import { ContactCards, LoadingContactCards } from './_components/contact-cards'
 import { ContactsPagination } from './_components/contacts-pagination'
 import { LoadingPagination } from './_components/contacts-pagination/pagination'
@@ -20,6 +21,7 @@ export default async function Contacts({ searchParams }: Props) {
 
   return (
     <div>
+      <ScrollAnchor page={page ?? '1'} />
       <h1 className="text-2xl font-bold">登録しているユーザー</h1>
       <p className="mt-1 text-sm">
         登録しているユーザーの一覧です。

--- a/src/components/scroll-anchor/index.tsx
+++ b/src/components/scroll-anchor/index.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import { useRef, useEffect } from 'react'
+
+type Props = {
+  page: string
+}
+
+// TEMP: https://github.com/vercel/next.js/issues/74485
+export function ScrollAnchor({ page }: Props) {
+  const ref = useRef<HTMLDivElement>(null)
+  const pageRef = useRef(page)
+
+  useEffect(() => {
+    if (page !== pageRef.current) {
+      ref.current?.scrollIntoView()
+      pageRef.current = page
+    }
+  }, [page])
+
+  return <div ref={ref} />
+}


### PR DESCRIPTION
### Summary

Add ScrollAnchor component to fix broken scroll-to-top behavior in Next.js 15 when loading.tsx is present. This addresses a known upstream issue where the Link component fails to automatically scroll to the top during page navigation in production environments.

### Changes

- Create ScrollAnchor component in `src/components/scroll-anchor/index.tsx` with manual scrollIntoView implementation
- Use useRef hooks to track page changes and trigger appropriate scroll behavior
- Integrate ScrollAnchor component with contacts page to restore expected scroll-to-top functionality
- Add temporary workaround comment referencing the upstream Next.js issue

### Testing

- Tested scroll-to-top behavior during pagination navigation in contacts page
- Verified component works correctly in both development and production environments
- Confirmed proper scroll behavior when navigating between different pages
- Validated that useRef implementation correctly tracks page state changes

### Related Issues

Refs: [Next.js 15 `<Link>` scroll to top does not work if `loading.tsx` is present · vercel/next.js](https://is.gd/yEfDzS)

### Notes

No additional information or considerations at this time.
