### PR TITLE
fix: adjust z-index for sidebar open button

### DIFF
--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -59,7 +59,7 @@ export function Sidebar({
         </div>
       </aside>
       {!isOpen && (
-        <div className="animate-slide-in-left bg-theme max-md:mb-safe absolute bottom-0.5 rounded-e-sm border-y border-r border-gray-300">
+        <div className="animate-slide-in-left bg-theme max-md:mb-safe absolute bottom-0.5 z-50 rounded-e-sm border-y border-r border-gray-300">
           <IconButton
             className="h-10 w-8 rounded-s-none"
             aria-label="サイドバーを開く"


### PR DESCRIPTION
### Summary

Fix layering issue with the sidebar open button by adding appropriate z-index styling. The button was appearing behind other elements, making it difficult or impossible for users to interact with it in certain UI states.

### Changes

- Add `z-50` class to the sidebar open button container in `src/components/sidebar/index.tsx`
- Ensure the button appears above other UI elements for proper user interaction
- Maintain existing styling and functionality while fixing the layering issue

### Testing

- Verified sidebar open button appears correctly above other UI elements
- Tested button interaction and click functionality across different screen sizes
- Confirmed no visual regressions with existing sidebar behavior
- Validated z-index value provides appropriate layering without conflicting with other components

### Related Issues

N/A

### Notes

No additional information or considerations at this time.
