### PR TITLE
feat: add collapsible bio section to user profile page

### DIFF
--- a/src/components/collapsible-sections/bio-collapsible-section/index.tsx
+++ b/src/components/collapsible-sections/bio-collapsible-section/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { CollapsibleSection } from '@/components/collapsible-section'
+import { CollapsibleSection } from '@/components/collapsible-sections/collapsible-section'
 
 type Props = Pick<
   React.ComponentProps<typeof CollapsibleSection>,

--- a/src/components/collapsible-sections/collapsible-section/index.tsx
+++ b/src/components/collapsible-sections/collapsible-section/index.tsx
@@ -72,7 +72,7 @@ export function CollapsibleSection({
         } ${className}`}
         onClick={handleClick}
       >
-        <span className="flex select-none justify-center gap-1 group-hover:stroke-black">
+        <span className="flex justify-center gap-1 select-none group-hover:stroke-black">
           {isCollapsed ? (
             <>
               <ChevronDownIcon className="size-4 self-center" />

--- a/src/components/pages/account-page/current-user-info/editable-bio/index.tsx
+++ b/src/components/pages/account-page/current-user-info/editable-bio/index.tsx
@@ -1,3 +1,4 @@
+import { BioCollapsibleSection } from '@/components/collapsible-sections/bio-collapsible-section'
 import { DetailItemHeading } from '@/components/headings/detail-item-heading'
 import { DetailItemContentLayout } from '@/components/layouts/detail-item-content-layout'
 import { DetailItemHeadingLayout } from '@/components/layouts/detail-item-heading-layout'
@@ -7,7 +8,6 @@ import {
   LoadingDetailMultiLineText,
 } from '@/components/texts/detail-multi-line-text'
 import { getCurrentUser } from '@/utils/api/server/get-current-user'
-import { BioCollapsibleSection } from './bio-collapsible-section'
 import { BioEditor } from './bio-editor'
 
 const height = 160

--- a/src/components/pages/user-page/index.tsx
+++ b/src/components/pages/user-page/index.tsx
@@ -1,5 +1,6 @@
 import { notFound, redirect } from 'next/navigation'
 import { Avatar, LoadingAvatar } from '@/components/avatars/avatar'
+import { BioCollapsibleSection } from '@/components/collapsible-sections/bio-collapsible-section'
 import { DetailItemHeading } from '@/components/headings/detail-item-heading'
 import { DetailItemContentLayout } from '@/components/layouts/detail-item-content-layout'
 import { DetailItemHeadingLayout } from '@/components/layouts/detail-item-heading-layout'
@@ -22,6 +23,7 @@ type Props = {
 const userInfoLayoutClasses = 'flex flex-col space-y-10'
 const avatarLayoutClasses = 'flex justify-center'
 const avatarSize = 128
+const bioCollapsibleHeight = 160
 
 export async function UserPage({ id }: Props) {
   const handleHttpError = async (err: HttpError) => {
@@ -64,13 +66,15 @@ export async function UserPage({ id }: Props) {
       <DetailItemHeadingLayout>
         <DetailItemHeading>自己紹介</DetailItemHeading>
       </DetailItemHeadingLayout>
-      <DetailItemContentLayout>
-        {user.bio === undefined ? (
-          <p className="text-gray-500">自己紹介は登録されていません...</p>
-        ) : (
-          <DetailMultiLineText>{user.bio}</DetailMultiLineText>
-        )}
-      </DetailItemContentLayout>
+      <BioCollapsibleSection height={bioCollapsibleHeight}>
+        <DetailItemContentLayout>
+          {user.bio === undefined ? (
+            <p className="text-gray-500">自己紹介は登録されていません...</p>
+          ) : (
+            <DetailMultiLineText>{user.bio}</DetailMultiLineText>
+          )}
+        </DetailItemContentLayout>
+      </BioCollapsibleSection>
     </div>
   )
 }
@@ -93,9 +97,11 @@ export function LoadingUserPage() {
         <DetailItemHeadingLayout>
           <DetailItemHeading>自己紹介</DetailItemHeading>
         </DetailItemHeadingLayout>
-        <DetailItemContentLayout>
-          <LoadingDetailMultiLineText lines={5} />
-        </DetailItemContentLayout>
+        <div style={{ height: `${bioCollapsibleHeight}px` }}>
+          <DetailItemContentLayout>
+            <LoadingDetailMultiLineText lines={6} />
+          </DetailItemContentLayout>
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
### Summary

Add collapsible bio section to user profile pages for consistent UX with account page and reorganize collapsible components into dedicated folder structure.

![screen-recording-85](https://github.com/user-attachments/assets/666711c4-7857-4a69-b226-674548477d95)


### Changes

- Create `src/components/collapsible-sections/` folder structure and move related components
- Add `BioCollapsibleSection` to user profile page with same functionality as account page  
- Implement 160px height constraint with expand/collapse functionality for bio sections
- Update all import paths after component reorganization
- Add loading state support with fixed height for consistent UI behavior

### Testing

- Verify user profile bio section displays correctly with proper styling
- Test bio text longer than 160px shows expand/collapse button functionality
- Confirm expand/collapse animation and state management works properly  
- Check loading state displays with correct height and skeleton content
- Verify account page bio section continues to work correctly after reorganization
- Test responsive behavior and accessibility on mobile devices

### Related Issues

N/A

### Notes

No additional information or considerations at this time.