### PR TITLE
feat: add display name and collapsible memo section to user profile page

### DIFF
--- a/src/components/collapsible-sections/memo-collapsible-section/index.tsx
+++ b/src/components/collapsible-sections/memo-collapsible-section/index.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import { CollapsibleSection } from '@/components/collapsible-sections/collapsible-section'
+
+type Props = Pick<
+  React.ComponentProps<typeof CollapsibleSection>,
+  'height' | 'children'
+>
+
+export function MemoCollapsibleSection({ height, children }: Props) {
+  return (
+    <CollapsibleSection height={height} className="z-10">
+      {children}
+    </CollapsibleSection>
+  )
+}

--- a/src/components/pages/user-page/index.tsx
+++ b/src/components/pages/user-page/index.tsx
@@ -1,7 +1,10 @@
 import { notFound, redirect } from 'next/navigation'
 import { Avatar, LoadingAvatar } from '@/components/avatars/avatar'
+import { Button } from '@/components/buttons/button'
 import { BioCollapsibleSection } from '@/components/collapsible-sections/bio-collapsible-section'
+import { MemoCollapsibleSection } from '@/components/collapsible-sections/memo-collapsible-section'
 import { DetailItemHeading } from '@/components/headings/detail-item-heading'
+import { HorizontalRule } from '@/components/horizontal-rule'
 import { DetailItemContentLayout } from '@/components/layouts/detail-item-content-layout'
 import { DetailItemHeadingLayout } from '@/components/layouts/detail-item-heading-layout'
 import {
@@ -24,6 +27,7 @@ const userInfoLayoutClasses = 'flex flex-col space-y-10'
 const avatarLayoutClasses = 'flex justify-center'
 const avatarSize = 128
 const bioCollapsibleHeight = 160
+const memoCollapsibleHeight = 160
 
 export async function UserPage({ id }: Props) {
   const handleHttpError = async (err: HttpError) => {
@@ -68,13 +72,63 @@ export async function UserPage({ id }: Props) {
       </DetailItemHeadingLayout>
       <BioCollapsibleSection height={bioCollapsibleHeight}>
         <DetailItemContentLayout>
-          {user.bio === undefined ? (
+          {user.bio === undefined || user.bio === '' ? (
             <p className="text-gray-500">自己紹介は登録されていません...</p>
           ) : (
             <DetailMultiLineText>{user.bio}</DetailMultiLineText>
           )}
         </DetailItemContentLayout>
       </BioCollapsibleSection>
+      <HorizontalRule />
+      {user.currentUserContact !== undefined ? (
+        <>
+          <DetailItemHeadingLayout>
+            <DetailItemHeading>表示名</DetailItemHeading>
+          </DetailItemHeadingLayout>
+          <DetailItemContentLayout>
+            {user.currentUserContact.displayName === undefined ? (
+              <p className="text-gray-500">表示名を設定できます...</p>
+            ) : (
+              <DetailSingleLineText>
+                {user.currentUserContact.displayName}
+              </DetailSingleLineText>
+            )}
+          </DetailItemContentLayout>
+          <DetailItemHeadingLayout>
+            <DetailItemHeading>メモ</DetailItemHeading>
+          </DetailItemHeadingLayout>
+          <MemoCollapsibleSection height={memoCollapsibleHeight}>
+            <DetailItemContentLayout>
+              {user.currentUserContact.note === undefined ? (
+                <p className="text-gray-500">メモを登録できます...</p>
+              ) : (
+                <DetailMultiLineText>
+                  {user.currentUserContact.note}
+                </DetailMultiLineText>
+              )}
+            </DetailItemContentLayout>
+          </MemoCollapsibleSection>
+        </>
+      ) : (
+        <DetailItemContentLayout>
+          <div className="rounded-sm bg-gray-100 p-6">
+            <div className="mb-6">
+              <p>
+                このユーザーは登録されていません。
+                <br />
+                ユーザーを登録すると以下ができるようになります。
+              </p>
+              <ul className="list-inside list-disc p-3">
+                <li>表示名の設定</li>
+                <li>メモの登録</li>
+                <li>チャット</li>
+                <li>テンプレートの共有</li>
+              </ul>
+            </div>
+            <Button className="btn-primary">登録</Button>
+          </div>
+        </DetailItemContentLayout>
+      )}
     </div>
   )
 }
@@ -98,6 +152,25 @@ export function LoadingUserPage() {
           <DetailItemHeading>自己紹介</DetailItemHeading>
         </DetailItemHeadingLayout>
         <div style={{ height: `${bioCollapsibleHeight}px` }}>
+          <DetailItemContentLayout>
+            <LoadingDetailMultiLineText lines={6} />
+          </DetailItemContentLayout>
+        </div>
+      </div>
+      <HorizontalRule />
+      <div>
+        <DetailItemHeadingLayout>
+          <DetailItemHeading>表示名</DetailItemHeading>
+        </DetailItemHeadingLayout>
+        <DetailItemContentLayout>
+          <LoadingDetailSingleLineText />
+        </DetailItemContentLayout>
+      </div>
+      <div>
+        <DetailItemHeadingLayout>
+          <DetailItemHeading>メモ</DetailItemHeading>
+        </DetailItemHeadingLayout>
+        <div style={{ height: `${memoCollapsibleHeight}px` }}>
           <DetailItemContentLayout>
             <LoadingDetailMultiLineText lines={6} />
           </DetailItemContentLayout>

--- a/src/utils/api/server/get-user.ts
+++ b/src/utils/api/server/get-user.ts
@@ -13,6 +13,13 @@ const dataSchema = z.object({
     name: z.string(),
     bio: z.string().optional(),
     avatar_url: z.string().optional(),
+    current_user_contact: z
+      .object({
+        id: z.number(),
+        display_name: z.string().optional(),
+        note: z.string().optional(),
+      })
+      .optional(),
   }),
 })
 


### PR DESCRIPTION
### Summary

Add display name field and memo section with collapsible functionality to the user profile page, enhancing the user information display with better organization and space efficiency.

![screen-recording-86](https://github.com/user-attachments/assets/ad299cd7-5772-4e65-934b-fe96db0ec0de)


### Changes

- Add `MemoCollapsibleSection` component for collapsible memo display
- Add display name field and memo section to user profile page
- Integrate collapsible functionality for memo section
- Update `get-user.ts` API schema to include `current_user_contact` data
- Add proper loading states for new sections

### Testing

- Tested collapsible functionality for memo section (expand/collapse behavior)
- Verified display name rendering with proper empty state messaging
- Confirmed loading states display correctly during data fetch

### Related Issues (Optional)

N/A

### Notes (Optional)

No additional information or considerations at this time.