### PR TITLE
feat: add contact registration functionality

### DIFF
--- a/src/app/(main)/users/contacts/get-contacts.api.ts
+++ b/src/app/(main)/users/contacts/get-contacts.api.ts
@@ -3,6 +3,7 @@ import camelcaseKeys from 'camelcase-keys'
 import { redirect } from 'next/navigation'
 import { cache } from 'react'
 import { z } from 'zod'
+import { contactSchema } from '@/schemas/response/contacts'
 import { fetchData } from '@/utils/api/fetch-data'
 import { getBearerToken } from '@/utils/cookie/bearer-token'
 import { HttpError } from '@/utils/error/custom/http-error'
@@ -11,19 +12,7 @@ import { getRequestId } from '@/utils/request-id/get-request-id'
 import { validateData } from '@/utils/validation/validate-data'
 
 const dataSchema = z.object({
-  contacts: z.array(
-    z.object({
-      id: z.number(),
-      display_name: z.string().optional(),
-      note: z.string().optional(),
-      contact_user: z.object({
-        id: z.number(),
-        name: z.string(),
-        bio: z.string().optional(),
-        avatar_url: z.string().optional(),
-      }),
-    }),
-  ),
+  contacts: z.array(contactSchema.shape.contact),
 })
 
 const paginationDataSchema = z.object({

--- a/src/components/pages/user-page/current-user-register-contact-button/index.tsx
+++ b/src/components/pages/user-page/current-user-register-contact-button/index.tsx
@@ -1,0 +1,21 @@
+import { getCurrentUser } from '@/utils/api/server/get-current-user'
+import { RegisterContactButton } from './register-contact-button.tsx'
+
+type Props = {
+  userId: React.ComponentProps<typeof RegisterContactButton>['contactUserId']
+}
+
+export async function CurrentUserRegistraterContactButton({ userId }: Props) {
+  const { account: currentUser } = await getCurrentUser()
+
+  return (
+    <RegisterContactButton
+      currentUserId={currentUser.id.toString()}
+      contactUserId={userId}
+    />
+  )
+}
+
+export function LoadingCurrentUserRegistraterContactButton() {
+  return <div className="skeleton shape-btn" />
+}

--- a/src/components/pages/user-page/current-user-register-contact-button/register-contact-button.tsx/create-contact.api.ts
+++ b/src/components/pages/user-page/current-user-register-contact-button/register-contact-button.tsx/create-contact.api.ts
@@ -1,0 +1,60 @@
+'use server'
+
+import camelcaseKeys from 'camelcase-keys'
+import { revalidatePath } from 'next/cache'
+import { contactSchema } from '@/schemas/response/contacts'
+import { ResultObject } from '@/types/api'
+import { fetchData } from '@/utils/api/fetch-data'
+import { getBearerToken } from '@/utils/cookie/bearer-token'
+import { createErrorObject } from '@/utils/error/create-error-object'
+import { getRequestId } from '@/utils/request-id/get-request-id'
+import { validateData } from '@/utils/validation/validate-data'
+import type { CamelCaseKeys } from 'camelcase-keys'
+import type { z } from 'zod'
+
+type Params = {
+  currentUserId: string
+  contactUserId: string
+}
+
+type Data = CamelCaseKeys<z.infer<typeof contactSchema>, true>
+
+export async function createContact({ currentUserId, contactUserId }: Params) {
+  const fetchDataResult = await fetchData(
+    `${process.env.API_ORIGIN}/api/v1/users/${currentUserId}/contacts`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: await getBearerToken(),
+      },
+      body: JSON.stringify({ contact_user_id: contactUserId }),
+    },
+  )
+
+  let resultObject: ResultObject<Data>
+
+  if (fetchDataResult instanceof Error) {
+    resultObject = createErrorObject(fetchDataResult)
+  } else {
+    const { headers, data } = fetchDataResult
+    const requestId = getRequestId(headers)
+    const validateDataResult = validateData({
+      requestId,
+      dataSchema: contactSchema,
+      data,
+    })
+
+    if (validateDataResult instanceof Error) {
+      resultObject = createErrorObject(validateDataResult)
+    } else {
+      resultObject = {
+        status: 'success',
+        ...camelcaseKeys(validateDataResult, { deep: true }),
+      }
+      revalidatePath(`/users/profile/${contactUserId}`)
+    }
+  }
+
+  return resultObject
+}

--- a/src/components/pages/user-page/current-user-register-contact-button/register-contact-button.tsx/index.tsx
+++ b/src/components/pages/user-page/current-user-register-contact-button/register-contact-button.tsx/index.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+import { Button } from '@/components/buttons/button'
+import { useRegisterContactButton } from './use-register-contact-button'
+
+type Props = {
+  currentUserId: string
+  contactUserId: string
+}
+
+export function RegisterContactButton({ currentUserId, contactUserId }: Props) {
+  const { isPending, handleClick } = useRegisterContactButton({
+    currentUserId,
+    contactUserId,
+  })
+
+  return (
+    <Button
+      className="btn-primary"
+      status={isPending ? 'pending' : 'idle'}
+      onClick={handleClick}
+    >
+      登録
+    </Button>
+  )
+}

--- a/src/components/pages/user-page/current-user-register-contact-button/register-contact-button.tsx/use-register-contact-button.tsx
+++ b/src/components/pages/user-page/current-user-register-contact-button/register-contact-button.tsx/use-register-contact-button.tsx
@@ -1,0 +1,68 @@
+import camelcaseKeys from 'camelcase-keys'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useCallback, useTransition } from 'react'
+import { z } from 'zod'
+import { useErrorSnackbar } from '@/app/_components/snackbars/snackbar/use-error-snackbar'
+import { ErrorObject } from '@/types/error'
+import { HttpError } from '@/utils/error/custom/http-error'
+import { useRedirectLoginPath } from '@/utils/login-path/use-redirect-login-path'
+import { isValidValue } from '@/utils/type-guard/is-valid-value'
+import { createContact } from './create-contact.api'
+
+type Params = {
+  currentUserId: string
+  contactUserId: string
+}
+
+const snackbarErrorsSchema = z.object({
+  errors: z.array(
+    z.object({
+      full_message: z.string(),
+    }),
+  ),
+})
+
+export function useRegisterContactButton({
+  currentUserId,
+  contactUserId,
+}: Params) {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const [isPending, startTransition] = useTransition()
+  const redirectLoginPath = useRedirectLoginPath({ searchParams })
+  const { openErrorSnackbar } = useErrorSnackbar()
+
+  const handleHttpError = useCallback(
+    (err: ErrorObject<HttpError>) => {
+      const { statusCode } = err
+      if (statusCode === 401) {
+        router.push(redirectLoginPath)
+      } else {
+        const { data } = err
+        if (isValidValue(snackbarErrorsSchema, data)) {
+          const camelcaseError = camelcaseKeys(data.errors[0])
+          openErrorSnackbar(err, camelcaseError.fullMessage)
+        }
+      }
+    },
+    [router, redirectLoginPath, openErrorSnackbar],
+  )
+
+  const handleClick = useCallback(() => {
+    startTransition(async () => {
+      const result = await createContact({ currentUserId, contactUserId })
+      if (result.status === 'error') {
+        if (result.name === 'HttpError') {
+          handleHttpError(result)
+        } else {
+          openErrorSnackbar(result)
+        }
+      }
+    })
+  }, [currentUserId, contactUserId, handleHttpError, openErrorSnackbar])
+
+  return {
+    isPending,
+    handleClick,
+  }
+}

--- a/src/components/pages/user-page/index.tsx
+++ b/src/components/pages/user-page/index.tsx
@@ -1,6 +1,6 @@
 import { notFound, redirect } from 'next/navigation'
+import { Suspense } from 'react'
 import { Avatar, LoadingAvatar } from '@/components/avatars/avatar'
-import { Button } from '@/components/buttons/button'
 import { BioCollapsibleSection } from '@/components/collapsible-sections/bio-collapsible-section'
 import { MemoCollapsibleSection } from '@/components/collapsible-sections/memo-collapsible-section'
 import { DetailItemHeading } from '@/components/headings/detail-item-heading'
@@ -18,6 +18,10 @@ import {
 import { getUser } from '@/utils/api/server/get-user'
 import { HttpError } from '@/utils/error/custom/http-error'
 import { generateRedirectLoginPath } from '@/utils/login-path/generate-redirect-login-path.server'
+import {
+  CurrentUserRegistraterContactButton,
+  LoadingCurrentUserRegistraterContactButton,
+} from './current-user-register-contact-button'
 
 type Props = {
   id: string
@@ -112,7 +116,7 @@ export async function UserPage({ id }: Props) {
       ) : (
         <DetailItemContentLayout>
           <div className="rounded-sm bg-gray-100 p-6">
-            <div className="mb-6">
+            <div className="mb-3">
               <p>
                 このユーザーは登録されていません。
                 <br />
@@ -125,7 +129,11 @@ export async function UserPage({ id }: Props) {
                 <li>テンプレートの共有</li>
               </ul>
             </div>
-            <Button className="btn-primary">登録</Button>
+            <Suspense fallback={<LoadingCurrentUserRegistraterContactButton />}>
+              <CurrentUserRegistraterContactButton
+                userId={user.id.toString()}
+              />
+            </Suspense>
           </div>
         </DetailItemContentLayout>
       )}

--- a/src/schemas/response/contacts.ts
+++ b/src/schemas/response/contacts.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod'
+
+export const contactSchema = z.object({
+  contact: z.object({
+    id: z.number(),
+    display_name: z.string().optional(),
+    note: z.string().optional(),
+    contact_user: z.object({
+      id: z.number(),
+      name: z.string(),
+      bio: z.string().optional(),
+      avatar_url: z.string().optional(),
+    }),
+  }),
+})


### PR DESCRIPTION
### Summary

Add comprehensive contact registration functionality that allows current users to register other users as contacts from their profile pages. This feature includes proper schema validation, loading states, and error handling.

![screen-recording-87](https://github.com/user-attachments/assets/6474d1e1-51fe-48eb-9901-be74d144dcec)

![screen-recording-88](https://github.com/user-attachments/assets/78329cd5-de4e-43a5-8d1b-4ddaaae28f0a)

### Changes

- **Contact schema validation**: Added `src/schemas/response/contacts.ts` for consistent API data validation
- **Contact registration button component**: Created reusable button component with loading states and proper error handling
- **API integration**: Added `create-contact.api.ts` with proper authentication and validation
- **User page integration**: Updated user profile pages to show contact registration option for non-registered users
- **Code optimization**: Refactored existing contact schema usage to use shared schema definition

### Testing

- Verified contact registration button appears for non-registered users
- Tested loading states during API calls
- Confirmed proper error handling for authentication failures
- Validated schema consistency across contact-related API calls

### Related Issues

N/A

### Notes

No additional information or considerations at this time.