### PR TITLE
fix: show placeholder text for empty strings in contact cards

### DIFF
--- a/src/app/(main)/users/contacts/_components/contact-cards/contact-card/index.tsx
+++ b/src/app/(main)/users/contacts/_components/contact-cards/contact-card/index.tsx
@@ -28,8 +28,8 @@ export function ContactCard({
   bio,
   avatarUrl,
 }: Props) {
-  const isBioUndefined = bio === undefined
-  const isNoteUndefined = note === undefined
+  const isBioEmpty = bio === undefined || bio === ''
+  const isNoteEmpty = note === undefined || note === ''
 
   return (
     <Link
@@ -44,23 +44,25 @@ export function ContactCard({
         />
         <div className={`min-w-0 ${contentContainerBaseClasses}`}>
           <h2 className="truncate text-lg font-bold">
-            {displayName === undefined ? contactUserName : displayName}
+            {displayName == undefined || displayName === ''
+              ? contactUserName
+              : displayName}
           </h2>
           <p
             className={`line-clamp-2 h-10 text-sm ${
-              isBioUndefined ? 'text-gray-500' : ''
+              isBioEmpty ? 'text-gray-500' : ''
             }`}
           >
-            {isBioUndefined ? '自己紹介は登録されていません...' : bio}
+            {isBioEmpty ? '自己紹介は登録されていません...' : bio}
           </p>
         </div>
       </div>
       <div className={memoSectionBaseClasses}>
         <h3 className={memoTitleClasses}>メモ</h3>
         <p
-          className={`line-clamp-2 h-10 text-sm ${isNoteUndefined ? 'text-gray-600/85' : ''}`}
+          className={`line-clamp-2 h-10 text-sm ${isNoteEmpty ? 'text-gray-600/85' : ''}`}
         >
-          {isNoteUndefined ? 'メモは登録されていません...' : note}
+          {isNoteEmpty ? 'メモは登録されていません...' : note}
         </p>
       </div>
     </Link>


### PR DESCRIPTION
### Summary

Fix empty string handling in contact cards to display appropriate placeholder text when bio, displayName, and note fields are empty strings, not just undefined values.

### Changes

- Updated variable names from isBioUndefined/isNoteUndefined to isBioEmpty/isNoteEmpty for better semantic clarity
- Enhanced bio, displayName, and note handling to also check for empty strings

### Testing

- Verified that placeholder text now appears correctly for empty string values in bio, displayName, and note fields
- Tested that non-empty values continue to display properly

### Related Issues

N/A

### Notes

No additional information or considerations at this time.