### PR TITLE
feat: add editable contact information with form protection

### DIFF
--- a/src/app/(main)/@modal/(.)account/_components/account-modal/index.tsx
+++ b/src/app/(main)/@modal/(.)account/_components/account-modal/index.tsx
@@ -2,11 +2,10 @@
 
 import { XMarkIcon } from '@heroicons/react/24/solid'
 import { useRouter } from 'next/navigation'
-import { useEffect, useRef } from 'react'
 import { IconButton } from '@/components/buttons/icon-button'
 import { ModalContent } from '@/components/contents/modal-content'
 import { Modal } from '@/components/modal'
-import { useModal } from '@/components/modal/use-modal'
+import { useFormModal } from '@/components/modal/use-form-modal'
 
 // TEMP: https://github.com/vercel/next.js/issues/58123
 // TEMP: https://github.com/vercel/next.js/issues/59316
@@ -14,72 +13,20 @@ import { useModal } from '@/components/modal/use-modal'
 type Props = Pick<React.ComponentProps<typeof ModalContent>, 'children'>
 
 export function AccountModal({ children }: Props) {
-  const shouldTriggerPopstate = useRef(true)
-  const isBackdropMouseDown = useRef(false)
   const router = useRouter()
-  const shouldCloseModal = useRef(true)
-  const { isOpen, closeModal, handleAnimationEnd, handleCancel } = useModal({
-    initialIsOpen: true,
+  const {
+    isOpen,
+    closeModal,
+    handleAnimationEnd,
+    handleCancel,
+    handleBackdropMouseDown,
+    handleBackdropClick,
+    handleMouseDownCapture,
+    handleBlurCapture,
+    handleClickCapture,
+  } = useFormModal({
+    skipPopstateButtonIds: ['confirm-delete-account-button', 'logout-button'],
   })
-
-  const handleBackdropMouseDown = () => {
-    isBackdropMouseDown.current = true
-    if (!shouldTriggerPopstate.current) {
-      shouldTriggerPopstate.current = true
-    }
-  }
-
-  const handleBackdropClick = () => {
-    if (shouldCloseModal.current) {
-      closeModal()
-    } else {
-      shouldCloseModal.current = true
-    }
-  }
-
-  const handleMouseDownCapture = () => {
-    if (!shouldTriggerPopstate.current) {
-      shouldTriggerPopstate.current = true
-    }
-  }
-
-  const handleBlurCapture = (ev: React.FocusEvent<HTMLDivElement>) => {
-    const blurredElementTag = ev.target.tagName
-    const isEditorBlurred = ['INPUT', 'TEXTAREA'].includes(blurredElementTag)
-
-    if (isEditorBlurred && isBackdropMouseDown.current) {
-      shouldCloseModal.current = false
-      if (isBackdropMouseDown.current) {
-        isBackdropMouseDown.current = false
-      }
-    }
-  }
-
-  const handleClickCapture = (ev: React.MouseEvent<HTMLDivElement>) => {
-    if (ev.target instanceof HTMLElement) {
-      const clickedElementId = ev.target.id
-      const buttonIds = ['confirm-delete-account-button', 'logout-button']
-
-      if (buttonIds.some((id) => clickedElementId.endsWith(id))) {
-        shouldTriggerPopstate.current = false
-      } else {
-        if (!shouldTriggerPopstate.current) {
-          shouldTriggerPopstate.current = true
-        }
-      }
-    }
-  }
-
-  // Trigger 'popstate' on unmount to address premature unmounting.
-  useEffect(() => {
-    return () => {
-      // Avoid 'popstate' on a screen transition button click.
-      if (shouldTriggerPopstate.current) {
-        const popstateEvent = new PopStateEvent('popstate')
-        window.dispatchEvent(popstateEvent)
-      }
-    }
-  }, [])
 
   return (
     <Modal

--- a/src/app/(main)/users/@modal/(.)profile/[id]/_components/user-modal/index.tsx
+++ b/src/app/(main)/users/@modal/(.)profile/[id]/_components/user-modal/index.tsx
@@ -5,15 +5,23 @@ import { useRouter } from 'next/navigation'
 import { IconButton } from '@/components/buttons/icon-button'
 import { ModalContent } from '@/components/contents/modal-content'
 import { Modal } from '@/components/modal'
-import { useModal } from '@/components/modal/use-modal'
+import { useFormModal } from '@/components/modal/use-form-modal'
 
 type Props = Pick<React.ComponentProps<typeof ModalContent>, 'children'>
 
 export function UserModal({ children }: Props) {
   const router = useRouter()
-  const { isOpen, closeModal, handleAnimationEnd, handleCancel } = useModal({
-    initialIsOpen: true,
-  })
+  const {
+    isOpen,
+    closeModal,
+    handleAnimationEnd,
+    handleCancel,
+    handleBackdropMouseDown,
+    handleBackdropClick,
+    handleMouseDownCapture,
+    handleBlurCapture,
+    handleClickCapture,
+  } = useFormModal()
 
   return (
     <Modal
@@ -21,21 +29,29 @@ export function UserModal({ children }: Props) {
       onAnimationEnd={handleAnimationEnd}
       onCancel={handleCancel}
       onClose={router.back}
-      onBackdropClick={closeModal}
+      onBackdropMouseDown={handleBackdropMouseDown}
+      onBackdropClick={handleBackdropClick}
     >
-      <ModalContent
-        upperLeftIcon={
-          <IconButton
-            type="button"
-            aria-label="モーダルを閉じる"
-            onClick={closeModal}
-          >
-            <XMarkIcon className="size-6" />
-          </IconButton>
-        }
+      <div
+        onMouseDownCapture={handleMouseDownCapture}
+        onBlurCapture={handleBlurCapture}
+        onClickCapture={handleClickCapture}
       >
-        {children}
-      </ModalContent>
+        <ModalContent
+          upperLeftIcon={
+            <IconButton
+              type="button"
+              tabIndex={0}
+              aria-label="モーダルを閉じる"
+              onClick={closeModal}
+            >
+              <XMarkIcon className="size-6" />
+            </IconButton>
+          }
+        >
+          {children}
+        </ModalContent>
+      </div>
     </Modal>
   )
 }

--- a/src/app/(main)/users/@modal/(.)profile/[id]/page.tsx
+++ b/src/app/(main)/users/@modal/(.)profile/[id]/page.tsx
@@ -1,4 +1,9 @@
 import { UserPage } from '@/components/pages/user-page'
+import type { Metadata } from 'next/types'
+
+export const metadata: Metadata = {
+  title: 'ユーザー詳細',
+}
 
 // TEMP: https://github.com/vercel/next.js/issues/58123
 // TEMP: https://github.com/vercel/next.js/issues/59316

--- a/src/app/(main)/users/profile/[id]/page.tsx
+++ b/src/app/(main)/users/profile/[id]/page.tsx
@@ -1,5 +1,10 @@
 import { Suspense } from 'react'
 import { UserPage, LoadingUserPage } from '@/components/pages/user-page'
+import type { Metadata } from 'next/types'
+
+export const metadata: Metadata = {
+  title: 'ユーザー詳細',
+}
 
 type Props = {
   params: Promise<{ id: string }>

--- a/src/components/modal/use-form-modal.tsx
+++ b/src/components/modal/use-form-modal.tsx
@@ -1,0 +1,92 @@
+import { useCallback, useEffect, useRef } from 'react'
+import { useModal } from '@/components/modal/use-modal'
+
+type Params = {
+  skipPopstateButtonIds?: string[]
+}
+
+export function useFormModal({ skipPopstateButtonIds = [] }: Params = {}) {
+  const { isOpen, closeModal, handleAnimationEnd, handleCancel } = useModal({
+    initialIsOpen: true,
+  })
+
+  const shouldTriggerPopstate = useRef(true)
+  const isBackdropMouseDown = useRef(false)
+  const shouldCloseModal = useRef(true)
+
+  const handleBackdropMouseDown = useCallback(() => {
+    isBackdropMouseDown.current = true
+    if (!shouldTriggerPopstate.current) {
+      shouldTriggerPopstate.current = true
+    }
+  }, [])
+
+  const handleBackdropClick = useCallback(() => {
+    if (shouldCloseModal.current) {
+      closeModal()
+    } else {
+      shouldCloseModal.current = true
+    }
+  }, [closeModal])
+
+  const handleMouseDownCapture = useCallback(() => {
+    if (!shouldTriggerPopstate.current) {
+      shouldTriggerPopstate.current = true
+    }
+  }, [])
+
+  const handleBlurCapture = useCallback(
+    (ev: React.FocusEvent<HTMLDivElement>) => {
+      const blurredElementTag = ev.target.tagName
+      const isFormFieldBlurred = ['INPUT', 'TEXTAREA'].includes(
+        blurredElementTag,
+      )
+
+      if (isFormFieldBlurred && isBackdropMouseDown.current) {
+        shouldCloseModal.current = false
+        if (isBackdropMouseDown.current) {
+          isBackdropMouseDown.current = false
+        }
+      }
+    },
+    [],
+  )
+
+  const handleClickCapture = useCallback(
+    (ev: React.MouseEvent<HTMLDivElement>) => {
+      if (ev.target instanceof HTMLElement) {
+        const clickedElementId = ev.target.id
+
+        if (skipPopstateButtonIds.some((id) => clickedElementId.endsWith(id))) {
+          shouldTriggerPopstate.current = false
+        } else {
+          if (!shouldTriggerPopstate.current) {
+            shouldTriggerPopstate.current = true
+          }
+        }
+      }
+    },
+    [skipPopstateButtonIds],
+  )
+
+  useEffect(() => {
+    return () => {
+      if (shouldTriggerPopstate.current) {
+        const popstateEvent = new PopStateEvent('popstate')
+        window.dispatchEvent(popstateEvent)
+      }
+    }
+  }, [])
+
+  return {
+    isOpen,
+    closeModal,
+    handleAnimationEnd,
+    handleCancel,
+    handleBackdropMouseDown,
+    handleBackdropClick,
+    handleMouseDownCapture,
+    handleBlurCapture,
+    handleClickCapture,
+  }
+}

--- a/src/components/pages/user-page/editable-display-name/display-name-editor/change-display-name.api.ts
+++ b/src/components/pages/user-page/editable-display-name/display-name-editor/change-display-name.api.ts
@@ -1,0 +1,67 @@
+'use server'
+
+import camelcaseKeys from 'camelcase-keys'
+import { revalidatePath } from 'next/cache'
+import snakecaseKeys from 'snakecase-keys'
+import { z } from 'zod'
+import { contactSchema } from '@/schemas/response/contacts'
+import { ResultObject } from '@/types/api'
+import { fetchData } from '@/utils/api/fetch-data'
+import { getBearerToken } from '@/utils/cookie/bearer-token'
+import { createErrorObject } from '@/utils/error/create-error-object'
+import { getRequestId } from '@/utils/request-id/get-request-id'
+import { validateData } from '@/utils/validation/validate-data'
+import type { CamelCaseKeys } from 'camelcase-keys'
+
+type Params = {
+  contactId: string
+  bodyData: {
+    displayName: string
+  }
+}
+
+type Data = CamelCaseKeys<z.infer<typeof contactSchema>, true>
+
+// 表示名変更API関数
+export async function changeDisplayName({ contactId, bodyData }: Params) {
+  // APIリクエストを送信
+  const fetchDataResult = await fetchData(
+    `${process.env.API_ORIGIN}/api/v1/contacts/${contactId}`, // 完全なURL
+    {
+      method: 'PATCH', // HTTPメソッド
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: await getBearerToken(), // 認証トークンを取得
+      },
+      body: JSON.stringify(snakecaseKeys(bodyData, { deep: false })), // リクエストボディをJSON文字列に変換
+    },
+  )
+
+  let resultObject: ResultObject<Data>
+
+  if (fetchDataResult instanceof Error) {
+    resultObject = createErrorObject(fetchDataResult) // エラーオブジェクトを作成
+  } else {
+    const { headers, data } = fetchDataResult
+    const requestId = getRequestId(headers) // レスポンスヘッダーからリクエストIDを取得
+    const validateDataResult = validateData({
+      requestId,
+      dataSchema: contactSchema, // レスポンスの検証スキーマ
+      data,
+    })
+
+    if (validateDataResult instanceof Error) {
+      resultObject = createErrorObject(validateDataResult) // バリデーションエラーの場合
+    } else {
+      resultObject = {
+        status: 'success',
+        ...camelcaseKeys(validateDataResult, { deep: true }), // snake_caseからcamelCaseに変換
+      }
+      // 成功時はページのキャッシュを更新
+      // TODO: 以下の記述は合っているのか。`id`と`contacts`のパス両方を記述する必要はあるのか。
+      revalidatePath(`/users/profile/${contactId}`) // ユーザープロフィールページのキャッシュを無効化
+    }
+  }
+
+  return resultObject // 結果を返す
+}

--- a/src/components/pages/user-page/editable-display-name/display-name-editor/index.tsx
+++ b/src/components/pages/user-page/editable-display-name/display-name-editor/index.tsx
@@ -1,0 +1,130 @@
+'use client'
+
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useRef, useTransition } from 'react'
+import { z } from 'zod'
+import { useErrorSnackbar } from '@/app/_components/snackbars/snackbar/use-error-snackbar'
+import { EditableText } from '@/components/editable-text'
+import { useEditableText } from '@/components/editable-text/use-editable-text'
+import { TextField } from '@/components/form-controls/text-field'
+import { DetailItemHeadingLayout } from '@/components/layouts/detail-item-heading-layout'
+import { ErrorObject } from '@/types/error'
+import { HttpError } from '@/utils/error/custom/http-error'
+import { useRedirectLoginPath } from '@/utils/login-path/use-redirect-login-path'
+import { countCharacters } from '@/utils/string-count/count-characters'
+import { changeDisplayName } from './change-display-name.api'
+
+type Props = Pick<React.ComponentProps<typeof EditableText>, 'children'> & {
+  currentUserId: string
+  contactId: string // コンタクトID
+  initialDisplayName: string | undefined // 初期表示名
+  label: React.ReactElement // ラベル要素
+  unsavedChangeTag: React.ReactElement // 未保存変更タグ要素
+}
+
+// 表示名変更のスキーマ定義
+const displayNameSchema = z.object({
+  displayName: z
+    .string() // 文字列型
+    .trim() // 前後の空白を削除
+    .refine((value) => countCharacters(value) <= 255, {
+      message: '255文字以下で入力してください。', // 最大255文字の制限
+    }),
+})
+
+// 型推論でフォームの値の型を定義
+type ChangeDisplayNameFormValue = z.infer<typeof displayNameSchema>
+
+// 表示名エディターコンポーネント
+export function DisplayNameEditor({
+  currentUserId,
+  contactId,
+  initialDisplayName = '',
+  label,
+  unsavedChangeTag,
+  children,
+}: Props) {
+  const [isPending, startTransition] = useTransition() // 送信状態の管理
+  const { openErrorSnackbar } = useErrorSnackbar() // エラースナックバーの表示
+  const router = useRouter() // ルーター
+  const searchParams = useSearchParams() // 検索パラメータ
+  const redirectLoginPath = useRedirectLoginPath({ searchParams }) // ログインページへのリダイレクトパス
+  const editorRef = useRef<HTMLInputElement>(null) // エディター要素の参照
+
+  // 編集可能テキストのカスタムフック
+  const {
+    updateField,
+    isEditorOpen,
+    hasLocalStorageValue,
+    handleFormSubmit,
+    handleCancelClick,
+    handleBlur,
+    registerReturn,
+    fieldError,
+    saveFieldValueToLocalStorage,
+    openEditor,
+  } = useEditableText<ChangeDisplayNameFormValue>({
+    editorRef,
+    currentUserId,
+    defaultValue: initialDisplayName,
+    schema: displayNameSchema,
+    name: 'displayName',
+    shouldSaveToLocalStorage: true, // ローカルストレージに保存する
+  })
+
+  // HTTPエラーの処理
+  const handleHttpError = (err: ErrorObject<HttpError>) => {
+    if (err.statusCode === 401) {
+      saveFieldValueToLocalStorage() // ローカルストレージに値を保存
+      router.push(redirectLoginPath) // ログインページにリダイレクト
+    } else {
+      openErrorSnackbar(err) // エラースナックバーを表示
+    }
+  }
+
+  // フォーム送信処理
+  const onSubmit = (data: ChangeDisplayNameFormValue) => {
+    startTransition(async () => {
+      const result = await changeDisplayName({ contactId, bodyData: data }) // 表示名変更APIを呼び出し
+      if (result.status === 'error') {
+        if (result.name === 'HttpError') {
+          handleHttpError(result) // HTTPエラーの処理
+        } else {
+          openErrorSnackbar(result) // その他のエラーの処理
+        }
+      } else {
+        updateField(result.contact.displayName ?? '') // 成功時はフィールドを更新
+      }
+    })
+  }
+
+  return (
+    <div>
+      <DetailItemHeadingLayout>
+        {label}
+        {/* 未保存の変更がある場合にタグを表示 */}
+        {hasLocalStorageValue && unsavedChangeTag}
+      </DetailItemHeadingLayout>
+      <EditableText
+        editor={
+          <TextField
+            ref={editorRef}
+            type="text"
+            readOnly={isPending} // 送信中は読み取り専用
+            register={registerReturn}
+            errors={fieldError}
+          />
+        }
+        onFormSubmit={handleFormSubmit(onSubmit)} // フォーム送信ハンドラー
+        onCancelClick={handleCancelClick} // キャンセルボタンのハンドラー
+        onBlur={handleBlur(onSubmit)} // フォーカス離脱時のハンドラー
+        isSubmitting={isPending} // 送信中の状態
+        hasLocalStorageValue={hasLocalStorageValue} // ローカルストレージに値があるかどうか
+        isEditorOpen={isEditorOpen || isPending} // エディターが開いているかどうか
+        openEditor={openEditor} // エディターを開く関数
+      >
+        {children}
+      </EditableText>
+    </div>
+  )
+}

--- a/src/components/pages/user-page/editable-display-name/display-name-editor/index.tsx
+++ b/src/components/pages/user-page/editable-display-name/display-name-editor/index.tsx
@@ -16,26 +16,23 @@ import { changeDisplayName } from './change-display-name.api'
 
 type Props = Pick<React.ComponentProps<typeof EditableText>, 'children'> & {
   currentUserId: string
-  contactId: string // コンタクトID
-  initialDisplayName: string | undefined // 初期表示名
-  label: React.ReactElement // ラベル要素
-  unsavedChangeTag: React.ReactElement // 未保存変更タグ要素
+  contactId: string
+  initialDisplayName: string | undefined
+  label: React.ReactElement
+  unsavedChangeTag: React.ReactElement
 }
 
-// 表示名変更のスキーマ定義
 const displayNameSchema = z.object({
   displayName: z
-    .string() // 文字列型
-    .trim() // 前後の空白を削除
+    .string()
+    .trim()
     .refine((value) => countCharacters(value) <= 255, {
-      message: '255文字以下で入力してください。', // 最大255文字の制限
+      message: '255文字以下で入力してください。',
     }),
 })
 
-// 型推論でフォームの値の型を定義
 type ChangeDisplayNameFormValue = z.infer<typeof displayNameSchema>
 
-// 表示名エディターコンポーネント
 export function DisplayNameEditor({
   currentUserId,
   contactId,
@@ -44,14 +41,13 @@ export function DisplayNameEditor({
   unsavedChangeTag,
   children,
 }: Props) {
-  const [isPending, startTransition] = useTransition() // 送信状態の管理
-  const { openErrorSnackbar } = useErrorSnackbar() // エラースナックバーの表示
-  const router = useRouter() // ルーター
-  const searchParams = useSearchParams() // 検索パラメータ
-  const redirectLoginPath = useRedirectLoginPath({ searchParams }) // ログインページへのリダイレクトパス
-  const editorRef = useRef<HTMLInputElement>(null) // エディター要素の参照
+  const [isPending, startTransition] = useTransition()
+  const { openErrorSnackbar } = useErrorSnackbar()
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const redirectLoginPath = useRedirectLoginPath({ searchParams })
+  const editorRef = useRef<HTMLInputElement>(null)
 
-  // 編集可能テキストのカスタムフック
   const {
     updateField,
     isEditorOpen,
@@ -69,31 +65,29 @@ export function DisplayNameEditor({
     defaultValue: initialDisplayName,
     schema: displayNameSchema,
     name: 'displayName',
-    shouldSaveToLocalStorage: true, // ローカルストレージに保存する
+    shouldSaveToLocalStorage: true,
   })
 
-  // HTTPエラーの処理
   const handleHttpError = (err: ErrorObject<HttpError>) => {
     if (err.statusCode === 401) {
-      saveFieldValueToLocalStorage() // ローカルストレージに値を保存
-      router.push(redirectLoginPath) // ログインページにリダイレクト
+      saveFieldValueToLocalStorage()
+      router.push(redirectLoginPath)
     } else {
-      openErrorSnackbar(err) // エラースナックバーを表示
+      openErrorSnackbar(err)
     }
   }
 
-  // フォーム送信処理
   const onSubmit = (data: ChangeDisplayNameFormValue) => {
     startTransition(async () => {
-      const result = await changeDisplayName({ contactId, bodyData: data }) // 表示名変更APIを呼び出し
+      const result = await changeDisplayName({ contactId, bodyData: data })
       if (result.status === 'error') {
         if (result.name === 'HttpError') {
-          handleHttpError(result) // HTTPエラーの処理
+          handleHttpError(result)
         } else {
-          openErrorSnackbar(result) // その他のエラーの処理
+          openErrorSnackbar(result)
         }
       } else {
-        updateField(result.contact.displayName ?? '') // 成功時はフィールドを更新
+        updateField(result.contact.displayName ?? '')
       }
     })
   }
@@ -102,7 +96,6 @@ export function DisplayNameEditor({
     <div>
       <DetailItemHeadingLayout>
         {label}
-        {/* 未保存の変更がある場合にタグを表示 */}
         {hasLocalStorageValue && unsavedChangeTag}
       </DetailItemHeadingLayout>
       <EditableText
@@ -110,18 +103,18 @@ export function DisplayNameEditor({
           <TextField
             ref={editorRef}
             type="text"
-            readOnly={isPending} // 送信中は読み取り専用
+            readOnly={isPending}
             register={registerReturn}
             errors={fieldError}
           />
         }
-        onFormSubmit={handleFormSubmit(onSubmit)} // フォーム送信ハンドラー
-        onCancelClick={handleCancelClick} // キャンセルボタンのハンドラー
-        onBlur={handleBlur(onSubmit)} // フォーカス離脱時のハンドラー
-        isSubmitting={isPending} // 送信中の状態
-        hasLocalStorageValue={hasLocalStorageValue} // ローカルストレージに値があるかどうか
-        isEditorOpen={isEditorOpen || isPending} // エディターが開いているかどうか
-        openEditor={openEditor} // エディターを開く関数
+        onFormSubmit={handleFormSubmit(onSubmit)}
+        onCancelClick={handleCancelClick}
+        onBlur={handleBlur(onSubmit)}
+        isSubmitting={isPending}
+        hasLocalStorageValue={hasLocalStorageValue}
+        isEditorOpen={isEditorOpen || isPending}
+        openEditor={openEditor}
       >
         {children}
       </EditableText>

--- a/src/components/pages/user-page/editable-display-name/index.tsx
+++ b/src/components/pages/user-page/editable-display-name/index.tsx
@@ -1,0 +1,54 @@
+import { DetailItemHeading } from '@/components/headings/detail-item-heading'
+import { DetailItemContentLayout } from '@/components/layouts/detail-item-content-layout'
+import { DetailItemHeadingLayout } from '@/components/layouts/detail-item-heading-layout'
+import { Tag } from '@/components/tag'
+import {
+  DetailSingleLineText,
+  LoadingDetailSingleLineText,
+} from '@/components/texts/detail-single-line-text'
+import { getCurrentUser } from '@/utils/api/server/get-current-user'
+import { DisplayNameEditor } from './display-name-editor'
+
+type Props = Pick<
+  React.ComponentProps<typeof DisplayNameEditor>,
+  'contactId'
+> & {
+  displayName: string | undefined
+}
+
+// 表示名の編集可能なコンポーネント
+export async function EditableDisplayName({ contactId, displayName }: Props) {
+  const { account: currentUser } = await getCurrentUser()
+
+  return (
+    <DisplayNameEditor
+      currentUserId={currentUser.id.toString()}
+      contactId={contactId} // コンタクトID
+      initialDisplayName={displayName} // 初期表示名（nullの場合は空文字）
+      label={<DetailItemHeading>表示名</DetailItemHeading>} // ラベル要素
+      unsavedChangeTag={<Tag color="warning">未保存の変更あり</Tag>} // 未保存変更タグ
+    >
+      <DetailItemContentLayout>
+        {displayName === undefined || displayName === '' ? (
+          <p className="text-gray-500">表示名を設定できます...</p> // 表示名未設定時のプレースホルダー
+        ) : (
+          <DetailSingleLineText>{displayName}</DetailSingleLineText> // 設定済みの表示名を表示
+        )}
+      </DetailItemContentLayout>
+    </DisplayNameEditor>
+  )
+}
+
+// ローディング状態のコンポーネント
+export function LoadingEditableDisplayName() {
+  return (
+    <div>
+      <DetailItemHeadingLayout>
+        <DetailItemHeading>表示名</DetailItemHeading>
+      </DetailItemHeadingLayout>
+      <DetailItemContentLayout>
+        <LoadingDetailSingleLineText /> {/* ローディング中のテキスト表示 */}
+      </DetailItemContentLayout>
+    </div>
+  )
+}

--- a/src/components/pages/user-page/editable-display-name/index.tsx
+++ b/src/components/pages/user-page/editable-display-name/index.tsx
@@ -16,30 +16,28 @@ type Props = Pick<
   displayName: string | undefined
 }
 
-// 表示名の編集可能なコンポーネント
 export async function EditableDisplayName({ contactId, displayName }: Props) {
   const { account: currentUser } = await getCurrentUser()
 
   return (
     <DisplayNameEditor
       currentUserId={currentUser.id.toString()}
-      contactId={contactId} // コンタクトID
-      initialDisplayName={displayName} // 初期表示名（nullの場合は空文字）
-      label={<DetailItemHeading>表示名</DetailItemHeading>} // ラベル要素
-      unsavedChangeTag={<Tag color="warning">未保存の変更あり</Tag>} // 未保存変更タグ
+      contactId={contactId}
+      initialDisplayName={displayName}
+      label={<DetailItemHeading>表示名</DetailItemHeading>}
+      unsavedChangeTag={<Tag color="warning">未保存の変更あり</Tag>}
     >
       <DetailItemContentLayout>
         {displayName === undefined || displayName === '' ? (
-          <p className="text-gray-500">表示名を設定できます...</p> // 表示名未設定時のプレースホルダー
+          <p className="text-gray-500">表示名を設定できます...</p>
         ) : (
-          <DetailSingleLineText>{displayName}</DetailSingleLineText> // 設定済みの表示名を表示
+          <DetailSingleLineText>{displayName}</DetailSingleLineText>
         )}
       </DetailItemContentLayout>
     </DisplayNameEditor>
   )
 }
 
-// ローディング状態のコンポーネント
 export function LoadingEditableDisplayName() {
   return (
     <div>
@@ -47,7 +45,7 @@ export function LoadingEditableDisplayName() {
         <DetailItemHeading>表示名</DetailItemHeading>
       </DetailItemHeadingLayout>
       <DetailItemContentLayout>
-        <LoadingDetailSingleLineText /> {/* ローディング中のテキスト表示 */}
+        <LoadingDetailSingleLineText />
       </DetailItemContentLayout>
     </div>
   )

--- a/src/components/pages/user-page/editable-note/index.tsx
+++ b/src/components/pages/user-page/editable-note/index.tsx
@@ -14,26 +14,25 @@ type Props = Pick<React.ComponentProps<typeof NoteEditor>, 'contactId'> & {
   note: string | undefined
 }
 
-const height = 160 // メモセクションの高さ
+const height = 160
 
-// メモの編集可能なコンポーネント
 export async function EditableNote({ contactId, note }: Props) {
   const { account: currentUser } = await getCurrentUser()
 
   return (
     <NoteEditor
       currentUserId={currentUser.id.toString()}
-      contactId={contactId} // コンタクトID
-      initialNote={note} // 初期メモ（nullの場合は空文字）
-      label={<DetailItemHeading>メモ</DetailItemHeading>} // ラベル要素
-      unsavedChangeTag={<Tag color="warning">未保存の変更あり</Tag>} // 未保存変更タグ
+      contactId={contactId}
+      initialNote={note}
+      label={<DetailItemHeading>メモ</DetailItemHeading>}
+      unsavedChangeTag={<Tag color="warning">未保存の変更あり</Tag>}
     >
       <NoteCollapsibleSection height={height}>
         <DetailItemContentLayout>
           {note === undefined || note === '' ? (
-            <p className="text-gray-500">メモを登録できます...</p> // メモ未設定時のプレースホルダー
+            <p className="text-gray-500">メモを登録できます...</p>
           ) : (
-            <DetailMultiLineText>{note}</DetailMultiLineText> // 設定済みのメモを表示
+            <DetailMultiLineText>{note}</DetailMultiLineText>
           )}
         </DetailItemContentLayout>
       </NoteCollapsibleSection>
@@ -41,7 +40,6 @@ export async function EditableNote({ contactId, note }: Props) {
   )
 }
 
-// ローディング状態のコンポーネント
 export function LoadingEditableNote() {
   return (
     <div>

--- a/src/components/pages/user-page/editable-note/index.tsx
+++ b/src/components/pages/user-page/editable-note/index.tsx
@@ -1,0 +1,58 @@
+import { DetailItemHeading } from '@/components/headings/detail-item-heading'
+import { DetailItemContentLayout } from '@/components/layouts/detail-item-content-layout'
+import { DetailItemHeadingLayout } from '@/components/layouts/detail-item-heading-layout'
+import { Tag } from '@/components/tag'
+import {
+  DetailMultiLineText,
+  LoadingDetailMultiLineText,
+} from '@/components/texts/detail-multi-line-text'
+import { getCurrentUser } from '@/utils/api/server/get-current-user'
+import { NoteCollapsibleSection } from './note-collapsible-section'
+import { NoteEditor } from './note-editor'
+
+type Props = Pick<React.ComponentProps<typeof NoteEditor>, 'contactId'> & {
+  note: string | undefined
+}
+
+const height = 160 // メモセクションの高さ
+
+// メモの編集可能なコンポーネント
+export async function EditableNote({ contactId, note }: Props) {
+  const { account: currentUser } = await getCurrentUser()
+
+  return (
+    <NoteEditor
+      currentUserId={currentUser.id.toString()}
+      contactId={contactId} // コンタクトID
+      initialNote={note} // 初期メモ（nullの場合は空文字）
+      label={<DetailItemHeading>メモ</DetailItemHeading>} // ラベル要素
+      unsavedChangeTag={<Tag color="warning">未保存の変更あり</Tag>} // 未保存変更タグ
+    >
+      <NoteCollapsibleSection height={height}>
+        <DetailItemContentLayout>
+          {note === undefined || note === '' ? (
+            <p className="text-gray-500">メモを登録できます...</p> // メモ未設定時のプレースホルダー
+          ) : (
+            <DetailMultiLineText>{note}</DetailMultiLineText> // 設定済みのメモを表示
+          )}
+        </DetailItemContentLayout>
+      </NoteCollapsibleSection>
+    </NoteEditor>
+  )
+}
+
+// ローディング状態のコンポーネント
+export function LoadingEditableNote() {
+  return (
+    <div>
+      <DetailItemHeadingLayout>
+        <DetailItemHeading>メモ</DetailItemHeading>
+      </DetailItemHeadingLayout>
+      <div style={{ height: `${height}px` }}>
+        <DetailItemContentLayout>
+          <LoadingDetailMultiLineText lines={6} />
+        </DetailItemContentLayout>
+      </div>
+    </div>
+  )
+}

--- a/src/components/pages/user-page/editable-note/note-collapsible-section/index.tsx
+++ b/src/components/pages/user-page/editable-note/note-collapsible-section/index.tsx
@@ -7,7 +7,7 @@ type Props = Pick<
   'height' | 'children'
 >
 
-export function MemoCollapsibleSection({ height, children }: Props) {
+export function NoteCollapsibleSection({ height, children }: Props) {
   return (
     <CollapsibleSection height={height} className="z-10">
       {children}

--- a/src/components/pages/user-page/editable-note/note-editor/change-note.api.ts
+++ b/src/components/pages/user-page/editable-note/note-editor/change-note.api.ts
@@ -1,0 +1,66 @@
+'use server'
+
+import camelcaseKeys from 'camelcase-keys'
+import { revalidatePath } from 'next/cache'
+import { z } from 'zod'
+import { contactSchema } from '@/schemas/response/contacts'
+import { ResultObject } from '@/types/api'
+import { fetchData } from '@/utils/api/fetch-data'
+import { getBearerToken } from '@/utils/cookie/bearer-token'
+import { createErrorObject } from '@/utils/error/create-error-object'
+import { getRequestId } from '@/utils/request-id/get-request-id'
+import { validateData } from '@/utils/validation/validate-data'
+import type { CamelCaseKeys } from 'camelcase-keys'
+
+type Params = {
+  contactId: string
+  bodyData: {
+    note: string
+  }
+}
+
+type Data = CamelCaseKeys<z.infer<typeof contactSchema>, true>
+
+// メモ変更API関数
+export async function changeNote({ contactId, bodyData }: Params) {
+  // APIリクエストを送信
+  const fetchDataResult = await fetchData(
+    `${process.env.API_ORIGIN}/api/v1/contacts/${contactId}`, // 完全なURL
+    {
+      method: 'PATCH', // HTTPメソッド
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: await getBearerToken(), // 認証トークンを取得
+      },
+      body: JSON.stringify(bodyData), // リクエストボディをJSON文字列に変換
+    },
+  )
+
+  let resultObject: ResultObject<Data>
+
+  if (fetchDataResult instanceof Error) {
+    resultObject = createErrorObject(fetchDataResult) // エラーオブジェクトを作成
+  } else {
+    const { headers, data } = fetchDataResult
+    const requestId = getRequestId(headers) // レスポンスヘッダーからリクエストIDを取得
+    const validateDataResult = validateData({
+      requestId,
+      dataSchema: contactSchema, // レスポンスの検証スキーマ
+      data,
+    })
+
+    if (validateDataResult instanceof Error) {
+      resultObject = createErrorObject(validateDataResult) // バリデーションエラーの場合
+    } else {
+      resultObject = {
+        status: 'success',
+        ...camelcaseKeys(validateDataResult, { deep: true }), // snake_caseからcamelCaseに変換
+      }
+      // 成功時はページのキャッシュを更新
+      // TODO: 以下の記述は合っているのか。`id`と`contacts`のパス両方を記述する必要はあるのか。
+      revalidatePath(`/users/profile/${contactId}`) // ユーザープロフィールページのキャッシュを無効化
+    }
+  }
+
+  return resultObject // 結果を返す
+}

--- a/src/components/pages/user-page/editable-note/note-editor/change-note.api.ts
+++ b/src/components/pages/user-page/editable-note/note-editor/change-note.api.ts
@@ -21,46 +21,42 @@ type Params = {
 
 type Data = CamelCaseKeys<z.infer<typeof contactSchema>, true>
 
-// メモ変更API関数
 export async function changeNote({ contactId, bodyData }: Params) {
-  // APIリクエストを送信
   const fetchDataResult = await fetchData(
-    `${process.env.API_ORIGIN}/api/v1/contacts/${contactId}`, // 完全なURL
+    `${process.env.API_ORIGIN}/api/v1/contacts/${contactId}`,
     {
-      method: 'PATCH', // HTTPメソッド
+      method: 'PATCH',
       headers: {
         'Content-Type': 'application/json',
-        Authorization: await getBearerToken(), // 認証トークンを取得
+        Authorization: await getBearerToken(),
       },
-      body: JSON.stringify(bodyData), // リクエストボディをJSON文字列に変換
+      body: JSON.stringify(bodyData),
     },
   )
 
   let resultObject: ResultObject<Data>
 
   if (fetchDataResult instanceof Error) {
-    resultObject = createErrorObject(fetchDataResult) // エラーオブジェクトを作成
+    resultObject = createErrorObject(fetchDataResult)
   } else {
     const { headers, data } = fetchDataResult
-    const requestId = getRequestId(headers) // レスポンスヘッダーからリクエストIDを取得
+    const requestId = getRequestId(headers)
     const validateDataResult = validateData({
       requestId,
-      dataSchema: contactSchema, // レスポンスの検証スキーマ
+      dataSchema: contactSchema,
       data,
     })
 
     if (validateDataResult instanceof Error) {
-      resultObject = createErrorObject(validateDataResult) // バリデーションエラーの場合
+      resultObject = createErrorObject(validateDataResult)
     } else {
       resultObject = {
         status: 'success',
-        ...camelcaseKeys(validateDataResult, { deep: true }), // snake_caseからcamelCaseに変換
+        ...camelcaseKeys(validateDataResult, { deep: true }),
       }
-      // 成功時はページのキャッシュを更新
-      // TODO: 以下の記述は合っているのか。`id`と`contacts`のパス両方を記述する必要はあるのか。
-      revalidatePath(`/users/profile/${contactId}`) // ユーザープロフィールページのキャッシュを無効化
+      revalidatePath(`/users/profile/${contactId}`)
     }
   }
 
-  return resultObject // 結果を返す
+  return resultObject
 }

--- a/src/components/pages/user-page/editable-note/note-editor/index.tsx
+++ b/src/components/pages/user-page/editable-note/note-editor/index.tsx
@@ -1,0 +1,142 @@
+'use client'
+
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useRef, useTransition } from 'react'
+import { z } from 'zod'
+import { useErrorSnackbar } from '@/app/_components/snackbars/snackbar/use-error-snackbar'
+import { EditableText } from '@/components/editable-text'
+import { useEditableMultiLineText } from '@/components/editable-text/use-editable-multi-line-text'
+import { useEditableText } from '@/components/editable-text/use-editable-text'
+import { TextArea } from '@/components/form-controls/text-area'
+import { DetailItemHeadingLayout } from '@/components/layouts/detail-item-heading-layout'
+import { ErrorObject } from '@/types/error'
+import { HttpError } from '@/utils/error/custom/http-error'
+import { useRedirectLoginPath } from '@/utils/login-path/use-redirect-login-path'
+import { countCharacters } from '@/utils/string-count/count-characters'
+import { changeNote } from './change-note.api'
+
+type Props = Pick<React.ComponentProps<typeof EditableText>, 'children'> & {
+  currentUserId: string
+  contactId: string // コンタクトID
+  initialNote: string | undefined // 初期メモ内容
+  label: React.ReactElement // ラベル要素
+  unsavedChangeTag: React.ReactElement // 未保存変更タグ要素
+}
+
+// メモ変更のスキーマ定義
+const noteSchema = z.object({
+  note: z
+    .string() // 文字列型
+    .trim() // 前後の空白を削除
+    .refine((value) => countCharacters(value) <= 1000, {
+      message: '最大文字数を超えています。',
+    }),
+})
+
+// 型推論でフォームの値の型を定義
+type ChangeNoteFormValue = z.infer<typeof noteSchema>
+
+// メモエディターコンポーネント
+export function NoteEditor({
+  currentUserId,
+  contactId,
+  initialNote = '',
+  label,
+  unsavedChangeTag,
+  children,
+}: Props) {
+  const [isPending, startTransition] = useTransition() // 送信状態の管理
+  const { openErrorSnackbar } = useErrorSnackbar() // エラースナックバーの表示
+  const router = useRouter() // ルーター
+  const searchParams = useSearchParams() // 検索パラメータ
+  const redirectLoginPath = useRedirectLoginPath({ searchParams }) // ログインページへのリダイレクトパス
+  const editorRef = useRef<HTMLTextAreaElement>(null) // エディター要素の参照
+
+  // 編集可能テキストのカスタムフック
+  const {
+    updateField,
+    isEditorOpen,
+    hasLocalStorageValue,
+    handleFormSubmit,
+    handleCancelClick,
+    handleBlur,
+    registerReturn,
+    fieldError,
+    saveFieldValueToLocalStorage,
+    openEditor,
+  } = useEditableText<ChangeNoteFormValue>({
+    editorRef,
+    currentUserId,
+    defaultValue: initialNote,
+    schema: noteSchema,
+    name: 'note',
+    shouldSaveToLocalStorage: true, // ローカルストレージに保存する
+  })
+
+  // 複数行テキスト用のカスタムフック
+  const { shadowRef, wordCount, handleInput } = useEditableMultiLineText({
+    editorRef,
+    isEditorOpen,
+  })
+
+  // HTTPエラーの処理
+  const handleHttpError = (err: ErrorObject<HttpError>) => {
+    if (err.statusCode === 401) {
+      saveFieldValueToLocalStorage() // ローカルストレージに値を保存
+      router.push(redirectLoginPath) // ログインページにリダイレクト
+    } else {
+      openErrorSnackbar(err) // エラースナックバーを表示
+    }
+  }
+
+  // フォーム送信処理
+  const onSubmit = (data: ChangeNoteFormValue) => {
+    startTransition(async () => {
+      const result = await changeNote({ contactId, bodyData: data }) // メモ変更APIを呼び出し
+      if (result.status === 'error') {
+        if (result.name === 'HttpError') {
+          handleHttpError(result) // HTTPエラーの処理
+        } else {
+          openErrorSnackbar(result) // その他のエラーの処理
+        }
+      } else {
+        updateField(result.contact.note ?? '') // 成功時はフィールドを更新
+      }
+    })
+  }
+
+  return (
+    <div>
+      <DetailItemHeadingLayout>
+        {label}
+        {/* 未保存の変更がある場合にタグを表示 */}
+        {hasLocalStorageValue && unsavedChangeTag}
+      </DetailItemHeadingLayout>
+      <EditableText
+        editor={
+          <TextArea
+            ref={editorRef}
+            shadowRef={shadowRef} // テキストエリア自動リサイズ用の影要素
+            rows={6} // 初期行数
+            readOnly={isPending} // 送信中は読み取り専用
+            wordCount={wordCount} // 文字数カウント
+            maxCount={1000} // 最大文字数
+            register={registerReturn}
+            errors={fieldError}
+            onInput={handleInput} // 入力時のハンドラー
+            placeholder="メモを入力してください"
+          />
+        }
+        isEditorOpen={isEditorOpen || isPending} // エディターが開いているかどうか
+        isSubmitting={isPending} // 送信中の状態
+        hasLocalStorageValue={hasLocalStorageValue} // ローカルストレージに値があるかどうか
+        onFormSubmit={handleFormSubmit(onSubmit)} // フォーム送信ハンドラー
+        onCancelClick={handleCancelClick} // キャンセルボタンのハンドラー
+        onBlur={handleBlur(onSubmit)} // フォーカス離脱時のハンドラー
+        openEditor={openEditor} // エディターを開く関数
+      >
+        {children}
+      </EditableText>
+    </div>
+  )
+}

--- a/src/components/pages/user-page/index.tsx
+++ b/src/components/pages/user-page/index.tsx
@@ -2,7 +2,6 @@ import { notFound, redirect } from 'next/navigation'
 import { Suspense } from 'react'
 import { Avatar, LoadingAvatar } from '@/components/avatars/avatar'
 import { BioCollapsibleSection } from '@/components/collapsible-sections/bio-collapsible-section'
-import { MemoCollapsibleSection } from '@/components/collapsible-sections/memo-collapsible-section'
 import { DetailItemHeading } from '@/components/headings/detail-item-heading'
 import { HorizontalRule } from '@/components/horizontal-rule'
 import { DetailItemContentLayout } from '@/components/layouts/detail-item-content-layout'
@@ -22,6 +21,11 @@ import {
   CurrentUserRegistraterContactButton,
   LoadingCurrentUserRegistraterContactButton,
 } from './current-user-register-contact-button'
+import {
+  EditableDisplayName,
+  LoadingEditableDisplayName,
+} from './editable-display-name'
+import { EditableNote, LoadingEditableNote } from './editable-note'
 
 type Props = {
   id: string
@@ -31,7 +35,6 @@ const userInfoLayoutClasses = 'flex flex-col space-y-10'
 const avatarLayoutClasses = 'flex justify-center'
 const avatarSize = 128
 const bioCollapsibleHeight = 160
-const memoCollapsibleHeight = 160
 
 export async function UserPage({ id }: Props) {
   const handleHttpError = async (err: HttpError) => {
@@ -84,36 +87,7 @@ export async function UserPage({ id }: Props) {
         </DetailItemContentLayout>
       </BioCollapsibleSection>
       <HorizontalRule />
-      {user.currentUserContact !== undefined ? (
-        <>
-          <DetailItemHeadingLayout>
-            <DetailItemHeading>表示名</DetailItemHeading>
-          </DetailItemHeadingLayout>
-          <DetailItemContentLayout>
-            {user.currentUserContact.displayName === undefined ? (
-              <p className="text-gray-500">表示名を設定できます...</p>
-            ) : (
-              <DetailSingleLineText>
-                {user.currentUserContact.displayName}
-              </DetailSingleLineText>
-            )}
-          </DetailItemContentLayout>
-          <DetailItemHeadingLayout>
-            <DetailItemHeading>メモ</DetailItemHeading>
-          </DetailItemHeadingLayout>
-          <MemoCollapsibleSection height={memoCollapsibleHeight}>
-            <DetailItemContentLayout>
-              {user.currentUserContact.note === undefined ? (
-                <p className="text-gray-500">メモを登録できます...</p>
-              ) : (
-                <DetailMultiLineText>
-                  {user.currentUserContact.note}
-                </DetailMultiLineText>
-              )}
-            </DetailItemContentLayout>
-          </MemoCollapsibleSection>
-        </>
-      ) : (
+      {user.currentUserContact === undefined ? (
         <DetailItemContentLayout>
           <div className="rounded-sm bg-gray-100 p-6">
             <div className="mb-3">
@@ -136,6 +110,17 @@ export async function UserPage({ id }: Props) {
             </Suspense>
           </div>
         </DetailItemContentLayout>
+      ) : (
+        <>
+          <EditableDisplayName
+            contactId={user.currentUserContact.id.toString()}
+            displayName={user.currentUserContact.displayName}
+          />
+          <EditableNote
+            contactId={user.currentUserContact.id.toString()}
+            note={user.currentUserContact.note}
+          />
+        </>
       )}
     </div>
   )
@@ -166,24 +151,8 @@ export function LoadingUserPage() {
         </div>
       </div>
       <HorizontalRule />
-      <div>
-        <DetailItemHeadingLayout>
-          <DetailItemHeading>表示名</DetailItemHeading>
-        </DetailItemHeadingLayout>
-        <DetailItemContentLayout>
-          <LoadingDetailSingleLineText />
-        </DetailItemContentLayout>
-      </div>
-      <div>
-        <DetailItemHeadingLayout>
-          <DetailItemHeading>メモ</DetailItemHeading>
-        </DetailItemHeadingLayout>
-        <div style={{ height: `${memoCollapsibleHeight}px` }}>
-          <DetailItemContentLayout>
-            <LoadingDetailMultiLineText lines={6} />
-          </DetailItemContentLayout>
-        </div>
-      </div>
+      <LoadingEditableDisplayName />
+      <LoadingEditableNote />
     </div>
   )
 }


### PR DESCRIPTION
### Summary
- Add editable display name and note functionality for contact information
- Implement form editing protection to prevent accidental modal closure
- Consolidate modal logic using shared useFormModal hook

### Changes
- Add EditableDisplayName component for updating contact display name
- Add EditableNote component for managing contact notes with collapsible interface
- Implement useFormModal hook to prevent accidental modal closure during editing
- Move memo collapsible section to user-page specific location for contact management
- Refactor AccountModal to use shared modal logic for consistency
- Include API endpoints for updating contact display name and note information

### Testing
- [ ] Verify contact display name can be edited inline
- [ ] Verify contact note can be edited with collapsible interface
- [ ] Verify modal does not close accidentally during form editing
- [ ] Verify backdrop click works normally when not editing contact forms
- [ ] Verify API calls work correctly for contact information updates

### Related Issues
N/A

### Notes
No additional information or considerations at this time.