### PR TITLE
fix: prevent long text overflow in contact cards

### DIFF
--- a/src/app/(main)/users/contacts/_components/contact-cards/contact-card/index.tsx
+++ b/src/app/(main)/users/contacts/_components/contact-cards/contact-card/index.tsx
@@ -49,7 +49,7 @@ export function ContactCard({
               : displayName}
           </h2>
           <p
-            className={`line-clamp-2 h-10 text-sm ${
+            className={`line-clamp-2 h-10 text-sm break-words ${
               isBioEmpty ? 'text-gray-500' : ''
             }`}
           >
@@ -60,7 +60,7 @@ export function ContactCard({
       <div className={memoSectionBaseClasses}>
         <h3 className={memoTitleClasses}>メモ</h3>
         <p
-          className={`line-clamp-2 h-10 text-sm ${isNoteEmpty ? 'text-gray-600/85' : ''}`}
+          className={`line-clamp-2 h-10 text-sm break-words ${isNoteEmpty ? 'text-gray-600/85' : ''}`}
         >
           {isNoteEmpty ? 'メモは登録されていません...' : note}
         </p>


### PR DESCRIPTION
### Summary

Fix text overflow issue in ContactCard component where long strings without spaces (such as URLs) would not wrap properly in note and bio fields.

![before-after-582](https://github.com/user-attachments/assets/06e757f9-bf3d-4bc2-a231-cf3c88268d35)

### Changes

- Add `break-words` CSS class to note and bio text elements in ContactCard component
- Ensures proper text wrapping for long continuous strings without spaces
- Maintains consistent display behavior across different content types

### Testing

- Verified that continuous text strings now wrap properly
- Confirmed that existing functionality remains unchanged
- All lint and formatting checks pass

### Related Issues (Optional)

N/A

### Notes (Optional)

No additional information or considerations at this time.