### PR TITLE
feat: add contact deletion functionality to user profile

### DIFF
--- a/src/components/modal/use-form-modal.tsx
+++ b/src/components/modal/use-form-modal.tsx
@@ -61,6 +61,7 @@ export function useFormModal({ skipPopstateButtonIds = [] }: Params = {}) {
           shouldTriggerPopstate.current = false
         } else {
           if (!shouldTriggerPopstate.current) {
+            // Exclude navigation other than back/forward
             shouldTriggerPopstate.current = true
           }
         }

--- a/src/components/pages/user-page/delete-contact-button/delete-contact.api.ts
+++ b/src/components/pages/user-page/delete-contact-button/delete-contact.api.ts
@@ -1,0 +1,52 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { z } from 'zod'
+import { ResultObject } from '@/types/api'
+import { fetchData } from '@/utils/api/fetch-data'
+import { getBearerToken } from '@/utils/cookie/bearer-token'
+import { createErrorObject } from '@/utils/error/create-error-object'
+import { getRequestId } from '@/utils/request-id/get-request-id'
+import { validateData } from '@/utils/validation/validate-data'
+
+const dataSchema = z.null()
+
+type Data = z.infer<typeof dataSchema>
+
+type Params = {
+  contactId: string
+  contactUserId: string
+}
+
+export async function deleteContact({ contactId, contactUserId }: Params) {
+  const fetchDataResult = await fetchData(
+    `${process.env.API_ORIGIN}/api/v1/contacts/${contactId}`,
+    {
+      method: 'DELETE',
+      headers: {
+        Authorization: await getBearerToken(),
+      },
+    },
+  )
+
+  let resultObject: ResultObject<Data>
+
+  if (fetchDataResult instanceof Error) {
+    resultObject = createErrorObject(fetchDataResult)
+  } else {
+    const { headers, data } = fetchDataResult
+    const requestId = getRequestId(headers)
+
+    const validateDataResult = validateData({ requestId, dataSchema, data })
+
+    if (validateDataResult instanceof Error) {
+      resultObject = createErrorObject(validateDataResult)
+    } else {
+      resultObject = { status: 'success' }
+
+      revalidatePath(`/users/profile/${contactUserId}`)
+    }
+  }
+
+  return resultObject
+}

--- a/src/components/pages/user-page/delete-contact-button/index.tsx
+++ b/src/components/pages/user-page/delete-contact-button/index.tsx
@@ -1,0 +1,115 @@
+'use client'
+
+import { XMarkIcon } from '@heroicons/react/24/solid'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useTransition } from 'react'
+import { useErrorSnackbar } from '@/app/_components/snackbars/snackbar/use-error-snackbar'
+import { Button } from '@/components/buttons/button'
+import { IconButton } from '@/components/buttons/icon-button'
+import { ModalContent } from '@/components/contents/modal-content'
+import { IconMessage } from '@/components/icon-message'
+import { Modal } from '@/components/modal'
+import { useModal } from '@/components/modal/use-modal'
+import { useRedirectLoginPath } from '@/utils/login-path/use-redirect-login-path'
+import { deleteContact } from './delete-contact.api'
+
+type Props = {
+  contactId: string
+  contactUserId: string
+}
+
+export function DeleteContactButton({ contactId, contactUserId }: Props) {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const redirectLoginPath = useRedirectLoginPath({ searchParams })
+  const [isPending, startTransition] = useTransition()
+  const { openErrorSnackbar } = useErrorSnackbar()
+  const {
+    shouldMount,
+    isOpen,
+    openModal,
+    closeModal,
+    unmountModal,
+    handleAnimationEnd,
+    handleCancel,
+  } = useModal()
+
+  const handleOkClick = () => {
+    closeModal()
+    startTransition(async () => {
+      const result = await deleteContact({ contactId, contactUserId })
+
+      if (result.status === 'error') {
+        if (result.name === 'HttpError' && result.statusCode === 401) {
+          router.push(redirectLoginPath)
+        } else {
+          openErrorSnackbar(result)
+        }
+      }
+    })
+  }
+
+  const handleClose = (ev: React.SyntheticEvent<HTMLDialogElement, Event>) => {
+    ev.stopPropagation()
+    unmountModal()
+  }
+
+  return (
+    <>
+      <Button
+        type="button"
+        className="btn-danger"
+        status={isPending ? 'pending' : 'idle'}
+        onClick={openModal}
+      >
+        登録解除
+      </Button>
+      {shouldMount && (
+        <Modal
+          isOpen={isOpen}
+          onAnimationEnd={handleAnimationEnd}
+          onCancel={handleCancel}
+          onClose={handleClose}
+          onBackdropClick={closeModal}
+        >
+          <ModalContent
+            upperLeftIcon={
+              <IconButton
+                type="button"
+                aria-label="モーダルを閉じる"
+                onClick={closeModal}
+              >
+                <XMarkIcon className="size-6" />
+              </IconButton>
+            }
+          >
+            <IconMessage severity="warning" title="確認">
+              <p className="mb-5 text-center">
+                本当に登録解除しますか？
+                <br />
+                解除すると、表示名やメモの情報も失われます。
+              </p>
+              <div className="mx-2.5 flex min-w-[16rem] items-center justify-center gap-5">
+                <Button
+                  type="button"
+                  className="btn-danger"
+                  status={isPending ? 'disabled' : 'idle'}
+                  onClick={handleOkClick}
+                >
+                  解除
+                </Button>
+                <Button
+                  type="button"
+                  className="btn-ghost"
+                  onClick={closeModal}
+                >
+                  キャンセル
+                </Button>
+              </div>
+            </IconMessage>
+          </ModalContent>
+        </Modal>
+      )}
+    </>
+  )
+}

--- a/src/components/pages/user-page/index.tsx
+++ b/src/components/pages/user-page/index.tsx
@@ -21,6 +21,7 @@ import {
   CurrentUserRegistraterContactButton,
   LoadingCurrentUserRegistraterContactButton,
 } from './current-user-register-contact-button'
+import { DeleteContactButton } from './delete-contact-button'
 import {
   EditableDisplayName,
   LoadingEditableDisplayName,
@@ -120,6 +121,12 @@ export async function UserPage({ id }: Props) {
             contactId={user.currentUserContact.id.toString()}
             note={user.currentUserContact.note}
           />
+          <DetailItemContentLayout>
+            <DeleteContactButton
+              contactId={user.currentUserContact.id.toString()}
+              contactUserId={user.id.toString()}
+            />
+          </DetailItemContentLayout>
         </>
       )}
     </div>
@@ -153,6 +160,9 @@ export function LoadingUserPage() {
       <HorizontalRule />
       <LoadingEditableDisplayName />
       <LoadingEditableNote />
+      <DetailItemContentLayout>
+        <div className="skeleton shape-btn" />
+      </DetailItemContentLayout>
     </div>
   )
 }


### PR DESCRIPTION
### Summary

Add contact deletion functionality to user profile page with confirmation modal.

### Changes

- Implement server action for `DELETE /api/v1/contacts/[contact_id]` API endpoint
- Create confirmation dialog using `useModal`, `Modal`, and `IconMessage` components  
- Add loading skeleton to LoadingUserPage for better UX

### Testing

- Verified delete button displays for registered contacts only
- Tested confirmation modal behavior (cancel/confirm)
- Confirmed user profile page reloads after successful deletion
- Verified login redirect on authentication error (401)
- Tested error snackbar display on failures

### Related Issues

N/A

### Notes

No additional information or considerations at this time.