### PR TITLE
feat: add loading UI for user profile modal page

### DIFF
--- a/src/app/(main)/users/@modal/(.)profile/[id]/loading.tsx
+++ b/src/app/(main)/users/@modal/(.)profile/[id]/loading.tsx
@@ -1,0 +1,10 @@
+import { LoadingPage } from '@/components/pages/loading-page'
+
+export default function Loading() {
+  return (
+    // 100dvh-2rem-6px:[Modal height] 1px:[Modal border] 6.75rem-env(safe-area-inset-bottom):[ModalContent padding]
+    <div className="h-[calc(100dvh-2rem-6px-1px-6.75rem-env(safe-area-inset-bottom))]">
+      <LoadingPage pageTitle="ユーザー詳細" />
+    </div>
+  )
+}

--- a/src/components/contents/modal-content/index.tsx
+++ b/src/components/contents/modal-content/index.tsx
@@ -10,7 +10,7 @@ export function ModalContent({
   children,
 }: Props) {
   return (
-    <div className={`px-1 pt-1 pb-safe md:pb-1 ${className}`}>
+    <div className={`pb-safe p-1 ${className}`}>
       {upperLeftIcon && <div className="p-2">{upperLeftIcon}</div>}
       <div className={`px-3 pb-12 md:px-12 ${upperLeftIcon ? '' : 'pt-12'}`}>
         {children}


### PR DESCRIPTION
### Summary

Add dedicated loading UI for user profile modal page with proper height calculation and simplify ModalContent padding classes for consistency.

### Changes

- **New loading UI**: Added `src/app/(main)/users/@modal/(.)profile/[id]/loading.tsx` with proper height calculation considering modal dimensions and safe area insets
- **ModalContent optimization**: Simplified padding classes in `src/components/contents/modal-content/index.tsx` from `px-1 pt-1 pb-safe md:pb-1` to `pb-safe p-1` for better consistency

### Testing

- Verified loading UI displays correctly when navigating to user profile modal
- Confirmed height calculation works properly with different screen sizes and safe area considerations
- Tested ModalContent padding changes maintain proper visual layout

![screen-recording-89](https://github.com/user-attachments/assets/11cd9bd2-1f4c-4d64-9a7b-fcb8634b5e1f)

### Related Issues

N/A

### Notes

No additional information or considerations at this time.