### PR TITLE
fix: update error object structure to match backend API response format

### DIFF
--- a/src/app/(main)/users/contacts/_components/current-user-create-contact-button/create-contact-button/use-create-contact-button.tsx
+++ b/src/app/(main)/users/contacts/_components/current-user-create-contact-button/create-contact-button/use-create-contact-button.tsx
@@ -1,5 +1,4 @@
 import { zodResolver } from '@hookform/resolvers/zod'
-import camelcaseKeys from 'camelcase-keys'
 import { useRouter } from 'next/navigation'
 import { useCallback, useTransition } from 'react'
 import { useForm } from 'react-hook-form'
@@ -22,7 +21,7 @@ const formErrorsSchema = createFormErrorsSchema(z.enum(['email']))
 const snackbarErrorsSchema = z.object({
   errors: z.array(
     z.object({
-      full_message: z.string(),
+      message: z.string(),
     }),
   ),
 })
@@ -73,8 +72,7 @@ export function useCreateContactButton({ currentUserId }: Params) {
       if (isValidValue(formErrorsSchema, data)) {
         handleFormErrors(data)
       } else if (isValidValue(snackbarErrorsSchema, data)) {
-        const camelcaseError = camelcaseKeys(data.errors[0])
-        openErrorSnackbar(err, camelcaseError.fullMessage)
+        openErrorSnackbar(err, data.errors[0].message)
       } else {
         openErrorSnackbar(err)
       }

--- a/src/utils/form/create-form-errors-schema.ts
+++ b/src/utils/form/create-form-errors-schema.ts
@@ -5,11 +5,11 @@ export function createFormErrorsSchema<
     | z.ZodLiteral<string>
     | z.ZodEnum<[string, ...string[]]>
     | z.ZodEffects<z.ZodLiteral<string> | z.ZodEnum<[string, ...string[]]>>,
->(attributeSchema: T) {
+>(sourceSchema: T) {
   const errorObjectSchema = z.object({
-    attribute: attributeSchema,
+    source: sourceSchema,
     type: z.string(),
-    full_message: z.string(),
+    message: z.string(),
   })
 
   return z.union([

--- a/src/utils/form/use-handle-form-error.tsx
+++ b/src/utils/form/use-handle-form-error.tsx
@@ -2,9 +2,9 @@ import { useCallback } from 'react'
 import type { FieldPath, FieldValues, UseFormSetError } from 'react-hook-form'
 
 type FormErrorItem<T extends FieldValues = FieldValues> = {
-  attribute: FieldPath<T>
+  source: FieldPath<T>
   type: string
-  full_message: string
+  message: string
 }
 
 type FormErrors<T extends FieldValues = FieldValues> = {
@@ -24,12 +24,12 @@ export function useHandleFormErrors<T extends FieldValues = FieldValues>(
   const handleFormErrors = useCallback(
     ({ shouldFocus = true, ...item }: FormErrors<T>) => {
       if ('errors' in item) {
-        item.errors.forEach(({ attribute, type, full_message }) => {
-          setError(attribute, { type, message: full_message }, { shouldFocus })
+        item.errors.forEach(({ source, type, message }) => {
+          setError(source, { type, message }, { shouldFocus })
         })
       } else {
-        const { attribute, type, full_message } = item.error
-        setError(attribute, { type, message: full_message }, { shouldFocus })
+        const { source, type, message } = item.error
+        setError(source, { type, message }, { shouldFocus })
       }
     },
     [setError],


### PR DESCRIPTION
### Summary

Update error object structure to match the new backend API response format. Change property names from `attribute`/`full_message` to `source`/`message` to ensure error messages are displayed correctly.

### Changes

- Updated error schema in `createFormErrorsSchema` function:
  - `attribute` → `source`
  - `full_message` → `message`
- Updated `FormErrorItem` type definition to use new property names
- Updated error handling logic in form error handler to use new properties
- Updated parameter name from `attributeSchema` to `sourceSchema` for consistency
- Removed unnecessary camelcase conversion in contact creation component

### Testing

- Linting and code formatting checks passed
- Build verification completed
- All automated quality checks (Knip, Markuplint, ESLint) passed
- Verified compatibility with new backend error response format

- Before
	<img width="2722" height="1812" alt="screen-shot-620" src="https://github.com/user-attachments/assets/420fa8b7-21cb-43f8-9e83-22fc3cbc61fd" />

- After
	<img width="2722" height="1812" alt="screen-shot-621" src="https://github.com/user-attachments/assets/63c6a60d-ccff-4f18-966a-be29eec2d0b1" />
	<img width="2728" height="1810" alt="screen-shot-622" src="https://github.com/user-attachments/assets/01360d11-8c68-447e-82e9-868c1421d41e" />

### Related Issues

N/A

### Notes

No additional information or considerations at this time.