### PR TITLE
feat: enable contact registration from user detail page for suggested users

### DIFF
--- a/src/app/(main)/users/suggestions/_components/suggestion-cards/create-contact-from-suggestion-button/create-contact-from-suggestion.api.ts
+++ b/src/app/(main)/users/suggestions/_components/suggestion-cards/create-contact-from-suggestion-button/create-contact-from-suggestion.api.ts
@@ -60,6 +60,7 @@ export async function createContactFromSuggestion({
         ...camelcaseKeys(validateDataResult, { deep: true }),
       }
       revalidatePath('/users/suggestions')
+      revalidatePath(`/users/profile/${contactUserId}`)
     }
   }
 

--- a/src/components/pages/user-page/create-contact-section/index.tsx
+++ b/src/components/pages/user-page/create-contact-section/index.tsx
@@ -1,0 +1,46 @@
+import Link from 'next/link'
+import { CreateContactFromSuggestionButton } from '@/app/(main)/users/suggestions/_components/suggestion-cards/create-contact-from-suggestion-button'
+import { getCurrentUser } from '@/utils/api/server/get-current-user'
+
+type Props = Pick<
+  React.ComponentProps<typeof CreateContactFromSuggestionButton>,
+  'userId'
+> & {
+  isSuggested: boolean
+}
+
+export async function CreateContactSection({ userId, isSuggested }: Props) {
+  const { account: currentUser } = await getCurrentUser()
+
+  return (
+    <div className="rounded-sm bg-gray-100 p-6">
+      <p>
+        このユーザーは登録されていません。
+        <br />
+        登録すると表示名やメモが設定できるようになります。
+      </p>
+      {isSuggested ? (
+        <>
+          <p>このユーザーを登録するには下のボタンをクリックしてください。</p>
+          <div className="mt-6">
+            <CreateContactFromSuggestionButton
+              userId={userId}
+              currentUserId={currentUser.id.toString()}
+            />
+          </div>
+        </>
+      ) : (
+        <>
+          <p>
+            このユーザーは「登録しているユーザー一覧」ページから登録できます。
+          </p>
+          <div className="mt-6">
+            <Link href="/users/contacts" className="btn btn-success">
+              登録しているユーザー一覧
+            </Link>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/components/pages/user-page/index.tsx
+++ b/src/components/pages/user-page/index.tsx
@@ -1,4 +1,3 @@
-import Link from 'next/link'
 import { Avatar, LoadingAvatar } from '@/components/avatars/avatar'
 import { BioCollapsibleSection } from '@/components/collapsible-sections/bio-collapsible-section'
 import { DetailItemHeading } from '@/components/headings/detail-item-heading'
@@ -14,6 +13,7 @@ import {
   LoadingDetailSingleLineText,
 } from '@/components/texts/detail-single-line-text'
 import { getUser } from '@/utils/api/server/get-user'
+import { CreateContactSection } from './create-contact-section'
 import { DeleteContactButton } from './delete-contact-button'
 import {
   EditableDisplayName,
@@ -62,32 +62,21 @@ export async function UserPage({ id }: Props) {
         </DetailItemContentLayout>
       </BioCollapsibleSection>
       <HorizontalRule />
-      {user.currentUserContact === undefined ? (
-        <div className="rounded-sm bg-gray-100 p-6">
-          <p>
-            このユーザーは登録されていません。
-            <br />
-            登録すると表示名やメモが設定できるようになります。
-            <br />
-            「登録しているユーザー一覧」ページで登録できます。
-          </p>
-          <Link href="/users/contacts" className="btn btn-success mt-6">
-            登録しているユーザー一覧
-          </Link>
-        </div>
+      {user.contact === undefined ? (
+        <CreateContactSection userId={user.id} isSuggested={user.isSuggested} />
       ) : (
         <>
           <EditableDisplayName
-            contactId={user.currentUserContact.id.toString()}
-            displayName={user.currentUserContact.displayName}
+            contactId={user.contact.id.toString()}
+            displayName={user.contact.displayName}
           />
           <EditableNote
-            contactId={user.currentUserContact.id.toString()}
-            note={user.currentUserContact.note}
+            contactId={user.contact.id.toString()}
+            note={user.contact.note}
           />
           <DetailItemContentLayout>
             <DeleteContactButton
-              contactId={user.currentUserContact.id.toString()}
+              contactId={user.contact.id.toString()}
               contactUserId={user.id.toString()}
             />
           </DetailItemContentLayout>

--- a/src/schemas/response/user.ts
+++ b/src/schemas/response/user.ts
@@ -6,12 +6,13 @@ export const userSchema = z.object({
     name: z.string(),
     bio: z.string().optional(),
     avatar_url: z.string().optional(),
-    current_user_contact: z
+    contact: z
       .object({
         id: z.number(),
         display_name: z.string().optional(),
         note: z.string().optional(),
       })
       .optional(),
+    is_suggested: z.boolean(),
   }),
 })

--- a/src/utils/api/get-suggestions.ts
+++ b/src/utils/api/get-suggestions.ts
@@ -12,7 +12,9 @@ import { getRequestId } from '@/utils/request-id/get-request-id'
 import { validateData } from '@/utils/validation/validate-data'
 
 const dataSchema = z.object({
-  users: z.array(userSchema.shape.user.omit({ current_user_contact: true })),
+  users: z.array(
+    userSchema.shape.user.omit({ contact: true, is_suggested: true }),
+  ),
 })
 
 const paginationDataSchema = z.object({


### PR DESCRIPTION
### Summary

Enable users to register suggested users as contacts directly from the user detail page. This feature adds a new contact registration flow that integrates with the existing suggestions system, providing a more streamlined user experience for managing contacts.

### Changes

- Add `CreateContactSection` component to handle contact registration UI with conditional display based on suggestion status
- Update user schema to include `contact` property (renamed from `current_user_contact`) and `is_suggested` boolean flag
- Integrate contact creation functionality from suggestions into user detail pages
- Add cache invalidation for user profile pages after successful contact creation
- Extract registration UI logic from UserPage component to improve code organization

### Testing

- Verify contact registration works correctly for suggested users from user detail page
- Confirm conditional UI displays appropriate options based on user suggestion status
- Test cache invalidation ensures immediate UI updates after contact creation
- Validate schema changes maintain backward compatibility with existing API responses

![screen-recording-95](https://github.com/user-attachments/assets/0091f2d7-9978-4835-abcc-5a3988514a48)

<img width="2728" height="1820" alt="screen-shot-631" src="https://github.com/user-attachments/assets/c2867617-59b2-4823-b8ad-996da6ce934f" />

### Related Issues

N/A

### Notes

No additional information or considerations at this time.