### PR TITLE
feat: add blocks user list page

### DIFF
--- a/src/app/(main)/users/_components/users-sidebar/users-menu/index.tsx
+++ b/src/app/(main)/users/_components/users-sidebar/users-menu/index.tsx
@@ -2,6 +2,7 @@ import {
   UsersIcon,
   UserCircleIcon,
   FaceSmileIcon,
+  NoSymbolIcon,
 } from '@heroicons/react/24/outline'
 import Link from 'next/link'
 import { useSelectedLayoutSegment } from 'next/navigation'
@@ -20,6 +21,11 @@ const links = [
     icon: <UserCircleIcon className="size-5" />,
     name: '登録している',
     pathname: '/users/contacts',
+  },
+  {
+    icon: <NoSymbolIcon className="size-5" />,
+    name: 'ブロックしている',
+    pathname: '/users/blocks',
   },
   {
     icon: <FaceSmileIcon className="size-5" />,

--- a/src/app/(main)/users/blocks/_components/blocks-cards/index.tsx
+++ b/src/app/(main)/users/blocks/_components/blocks-cards/index.tsx
@@ -1,0 +1,44 @@
+import { EmptyList } from '@/components/empty-list'
+import { UserCard, LoadingUserCard } from '@/components/user-card'
+import { getBlocks } from '@/utils/api/get-blocks'
+import { getCurrentUser } from '@/utils/api/server/get-current-user'
+
+type Props = {
+  page: string
+}
+
+const cardsLayoutClasses =
+  'grid gap-4 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3'
+
+export async function BlocksCards({ page }: Props) {
+  const { account: currentUser } = await getCurrentUser()
+  const { blocks } = await getBlocks(currentUser.id.toString(), page)
+
+  return blocks.length === 0 ? (
+    <div className="my-28 md:my-48">
+      <EmptyList description="ブロックしているユーザーは存在しません。" />
+    </div>
+  ) : (
+    <div className={cardsLayoutClasses}>
+      {blocks.map((block) => (
+        <UserCard
+          key={block.blocked.id}
+          id={block.blocked.id}
+          name={block.blocked.name}
+          bio={block.blocked.bio}
+          avatarUrl={block.blocked.avatarUrl}
+        />
+      ))}
+    </div>
+  )
+}
+
+export function LoadingBlocksCards() {
+  return (
+    <div className={cardsLayoutClasses}>
+      {Array.from({ length: 18 }).map((_, index) => (
+        <LoadingUserCard key={index} />
+      ))}
+    </div>
+  )
+}

--- a/src/app/(main)/users/blocks/_components/blocks-pagination/index.tsx
+++ b/src/app/(main)/users/blocks/_components/blocks-pagination/index.tsx
@@ -1,0 +1,14 @@
+import { Pagination } from '@/components/pagination'
+import { getBlocks } from '@/utils/api/get-blocks'
+import { getCurrentUser } from '@/utils/api/server/get-current-user'
+
+type Props = {
+  page: string
+}
+
+export async function BlocksPagination({ page }: Props) {
+  const { account: currentUser } = await getCurrentUser()
+  const { pagination } = await getBlocks(currentUser.id.toString(), page)
+
+  return pagination.totalPages > 1 ? <Pagination {...pagination} /> : null
+}

--- a/src/app/(main)/users/blocks/error.tsx
+++ b/src/app/(main)/users/blocks/error.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import { Button } from '@/components/buttons/button'
+import { ErrorContent } from '@/components/contents/error-content'
+import { IconMessage } from '@/components/icon-message'
+import { ReportIssueLink } from '@/components/report-issue-link'
+import type { ErrorProps } from '@/types/error'
+
+export default function Error({ error, reset }: ErrorProps) {
+  return (
+    <div className="p-20">
+      <IconMessage severity="error" title="Error">
+        <ErrorContent
+          message="ブロックしているユーザー一覧の表示中に問題が発生しました。"
+          resetButton={
+            <Button type="button" className="btn-success" onClick={reset}>
+              再読み込み
+            </Button>
+          }
+          reportIssueLink={<ReportIssueLink info={`Digest: ${error.digest}`} />}
+        />
+      </IconMessage>
+    </div>
+  )
+}

--- a/src/app/(main)/users/blocks/loading.tsx
+++ b/src/app/(main)/users/blocks/loading.tsx
@@ -1,0 +1,5 @@
+import { LoadingPage } from '@/components/pages/loading-page'
+
+export default function Loading() {
+  return <LoadingPage pageTitle="ブロックしているユーザー一覧" />
+}

--- a/src/app/(main)/users/blocks/page.tsx
+++ b/src/app/(main)/users/blocks/page.tsx
@@ -1,0 +1,51 @@
+import { Suspense } from 'react'
+import { UsersHeading } from '@/components/headings/users-heading'
+import { UsersHeaderLayout } from '@/components/layouts/users-header-layout'
+import { LoadingPagination } from '@/components/pagination'
+import { ScrollAnchor } from '@/components/scroll-anchor'
+import { UsersDescription } from '@/components/texts/users-description'
+import { BlocksCards, LoadingBlocksCards } from './_components/blocks-cards'
+import { BlocksPagination } from './_components/blocks-pagination'
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'ブロックしているユーザー一覧',
+}
+
+type Props = {
+  searchParams: Promise<{
+    page?: string
+  }>
+}
+
+export default async function Blocks({ searchParams }: Props) {
+  const params = await searchParams
+  const { page } = params
+
+  return (
+    <div>
+      <ScrollAnchor page={page ?? '1'} />
+      <UsersHeaderLayout>
+        <UsersHeading>ブロックしているユーザー</UsersHeading>
+        <UsersDescription>
+          あなたがブロックしているユーザーの一覧です。
+          <br />
+          ブロックしているユーザーのアクションは非表示になり、あなたを登録できなくなります。
+        </UsersDescription>
+      </UsersHeaderLayout>
+      <div className="mt-5">
+        <Suspense key={page} fallback={<LoadingBlocksCards />}>
+          <BlocksCards page={page ?? '1'} />
+        </Suspense>
+      </div>
+      <div className="mt-6">
+        <Suspense
+          key={page}
+          fallback={page === undefined ? null : <LoadingPagination />}
+        >
+          <BlocksPagination page={page ?? '1'} />
+        </Suspense>
+      </div>
+    </div>
+  )
+}

--- a/src/app/(main)/users/contacts/get-contacts.api.ts
+++ b/src/app/(main)/users/contacts/get-contacts.api.ts
@@ -4,22 +4,17 @@ import { redirect } from 'next/navigation'
 import { cache } from 'react'
 import { z } from 'zod'
 import { contactSchema } from '@/schemas/response/contacts'
+import { paginationDataSchema } from '@/schemas/response/pagination'
 import { fetchData } from '@/utils/api/fetch-data'
 import { getBearerToken } from '@/utils/cookie/bearer-token'
 import { HttpError } from '@/utils/error/custom/http-error'
+import { extractPaginationData } from '@/utils/header/extract-pagination-data'
 import { generateRedirectLoginPath } from '@/utils/login-path/generate-redirect-login-path.server'
 import { getRequestId } from '@/utils/request-id/get-request-id'
 import { validateData } from '@/utils/validation/validate-data'
 
 const dataSchema = z.object({
   contacts: z.array(contactSchema.shape.contact),
-})
-
-const paginationDataSchema = z.object({
-  currentPage: z.coerce.number().int().positive(),
-  pageItems: z.coerce.number().int().nonnegative(),
-  totalPages: z.coerce.number().int().positive(),
-  totalCount: z.coerce.number().int().nonnegative(),
 })
 
 export const getContacts = cache(
@@ -56,12 +51,7 @@ export const getContacts = cache(
 
     const { contacts } = camelcaseKeys(validateDataResult, { deep: true })
 
-    const paginationData = {
-      currentPage: headers.get('current-page'),
-      pageItems: headers.get('page-items'),
-      totalPages: headers.get('total-pages'),
-      totalCount: headers.get('total-count'),
-    }
+    const paginationData = extractPaginationData(headers)
 
     const validatePaginationResult = validateData({
       requestId,

--- a/src/schemas/response/pagination.ts
+++ b/src/schemas/response/pagination.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod'
+
+export const paginationDataSchema = z.object({
+  currentPage: z.coerce.number().int().positive(),
+  pageItems: z.coerce.number().int().nonnegative(),
+  totalPages: z.coerce.number().int().positive(),
+  totalCount: z.coerce.number().int().nonnegative(),
+})

--- a/src/utils/header/extract-pagination-data.ts
+++ b/src/utils/header/extract-pagination-data.ts
@@ -1,0 +1,8 @@
+export function extractPaginationData(headers: Headers) {
+  return {
+    currentPage: headers.get('current-page'),
+    pageItems: headers.get('page-items'),
+    totalPages: headers.get('total-pages'),
+    totalCount: headers.get('total-count'),
+  }
+}


### PR DESCRIPTION
### Summary

Add comprehensive blocked users list page with pagination and proper loading/error states for users to view and manage their blocked users.

### Changes

- Add blocks list page with proper Next.js App Router structure
- Create BlocksCards component to display blocked users in responsive grid layout
- Create BlocksPagination component for paginated navigation
- Implement getBlocks API with authentication handling and error management
- Add blocks navigation menu item with NoSymbolIcon in users sidebar
- Extract pagination logic to shared utilities for better code reuse
- Add proper loading and error boundary pages for the blocks feature

### Testing

- Verified responsive grid layout across different screen sizes
- Tested pagination functionality with proper URL state management
- Confirmed proper loading states and error handling
- Validated authentication flow and 401 redirect behavior
- Checked navigation integration with existing user sidebar

<img width="2730" height="1820" alt="screen-shot-636" src="https://github.com/user-attachments/assets/e9b2d536-cb9f-4a63-8c79-46388fad51f8" />

<img width="2730" height="1820" alt="screen-shot-637" src="https://github.com/user-attachments/assets/97c09ca7-89e8-49b9-a9f5-f11536cb09ba" />

<img width="2730" height="1820" alt="screen-shot-638" src="https://github.com/user-attachments/assets/d4a0875b-f1b8-4a20-aa28-949e3e266a63" />

<img width="2726" height="1826" alt="screen-shot-635" src="https://github.com/user-attachments/assets/81866dd2-ee7c-4ab6-ac73-80c5e5ca5958" />

### Related Issues (Optional)

N/A

### Notes (Optional)

This implementation provides the foundation for the block management system. The delete functionality (unblock button) will be added in a follow-up PR that builds on this foundation.