### PR TITLE
feat: add delete block button with confirmation modal to blocks list

### DIFF
--- a/src/app/(main)/users/blocks/_components/blocks-cards/delete-block-button/delete-block.api.ts
+++ b/src/app/(main)/users/blocks/_components/blocks-cards/delete-block-button/delete-block.api.ts
@@ -1,0 +1,49 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { z } from 'zod'
+import { ResultObject } from '@/types/api'
+import { fetchData } from '@/utils/api/fetch-data'
+import { getBearerToken } from '@/utils/cookie/bearer-token'
+import { createErrorObject } from '@/utils/error/create-error-object'
+import { getRequestId } from '@/utils/request-id/get-request-id'
+import { validateData } from '@/utils/validation/validate-data'
+
+const dataSchema = z.null()
+type Data = z.infer<typeof dataSchema>
+
+type Params = {
+  blockId: number
+}
+
+export async function deleteBlock({ blockId }: Params) {
+  const fetchDataResult = await fetchData(
+    `${process.env.API_ORIGIN}/api/v1/blocks/${blockId}`,
+    {
+      method: 'DELETE',
+      headers: {
+        Authorization: await getBearerToken(),
+      },
+    },
+  )
+
+  let resultObject: ResultObject<Data>
+
+  if (fetchDataResult instanceof Error) {
+    resultObject = createErrorObject(fetchDataResult)
+  } else {
+    const { headers, data } = fetchDataResult
+    const requestId = getRequestId(headers)
+
+    const validateDataResult = validateData({ requestId, dataSchema, data })
+
+    if (validateDataResult instanceof Error) {
+      resultObject = createErrorObject(validateDataResult)
+    } else {
+      resultObject = { status: 'success' }
+      revalidatePath('/users/blocks')
+    }
+  }
+
+  return resultObject
+}

--- a/src/app/(main)/users/blocks/_components/blocks-cards/delete-block-button/index.tsx
+++ b/src/app/(main)/users/blocks/_components/blocks-cards/delete-block-button/index.tsx
@@ -1,0 +1,111 @@
+'use client'
+
+import { XMarkIcon } from '@heroicons/react/24/solid'
+import { useSearchParams } from 'next/navigation'
+import { useRouter } from 'next/navigation'
+import { useTransition } from 'react'
+import { useErrorSnackbar } from '@/app/_components/snackbars/snackbar/use-error-snackbar'
+import { Button } from '@/components/buttons/button'
+import { IconButton } from '@/components/buttons/icon-button'
+import { ModalContent } from '@/components/contents/modal-content'
+import { IconMessage } from '@/components/icon-message'
+import { Modal } from '@/components/modal'
+import { useModal } from '@/components/modal/use-modal'
+import { useRedirectLoginPath } from '@/utils/login-path/use-redirect-login-path'
+import { deleteBlock } from './delete-block.api'
+
+type Props = {
+  blockId: number
+}
+
+export function DeleteBlockButton({ blockId }: Props) {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const redirectLoginPath = useRedirectLoginPath({ searchParams })
+  const [isPending, startTransition] = useTransition()
+  const { openErrorSnackbar } = useErrorSnackbar()
+  const {
+    shouldMount,
+    isOpen,
+    openModal,
+    closeModal,
+    unmountModal,
+    handleAnimationEnd,
+    handleCancel,
+  } = useModal()
+
+  const handleOkClick = () => {
+    closeModal()
+    startTransition(async () => {
+      const result = await deleteBlock({ blockId })
+
+      if (result.status === 'error') {
+        if (result.name === 'HttpError' && result.statusCode === 401) {
+          router.push(redirectLoginPath)
+        } else {
+          openErrorSnackbar(result)
+        }
+      }
+    })
+  }
+
+  const handleClose = (ev: React.SyntheticEvent<HTMLDialogElement, Event>) => {
+    ev.stopPropagation()
+    unmountModal()
+  }
+
+  return (
+    <>
+      <Button
+        type="button"
+        className="btn-danger"
+        status={isPending ? 'pending' : 'idle'}
+        onClick={openModal}
+      >
+        解除
+      </Button>
+      {shouldMount && (
+        <Modal
+          isOpen={isOpen}
+          onAnimationEnd={handleAnimationEnd}
+          onCancel={handleCancel}
+          onClose={handleClose}
+          onBackdropClick={closeModal}
+        >
+          <ModalContent
+            upperLeftIcon={
+              <IconButton
+                type="button"
+                aria-label="モーダルを閉じる"
+                onClick={closeModal}
+              >
+                <XMarkIcon className="size-6" />
+              </IconButton>
+            }
+          >
+            <IconMessage severity="warning" title="確認">
+              <p className="mb-5 text-center">本当にブロックを解除しますか？</p>
+              <div className="flex items-center justify-center gap-5">
+                <Button
+                  type="button"
+                  className="btn-danger"
+                  status={isPending ? 'disabled' : 'idle'}
+                  onClick={handleOkClick}
+                >
+                  解除
+                </Button>
+                <Button
+                  type="button"
+                  className="btn-ghost"
+                  onClick={closeModal}
+                >
+                  キャンセル
+                </Button>
+              </div>
+            </IconMessage>
+          </ModalContent>
+        </Modal>
+      )}
+    </>
+  )
+}

--- a/src/app/(main)/users/blocks/_components/blocks-cards/index.tsx
+++ b/src/app/(main)/users/blocks/_components/blocks-cards/index.tsx
@@ -2,6 +2,7 @@ import { EmptyList } from '@/components/empty-list'
 import { UserCard, LoadingUserCard } from '@/components/user-card'
 import { getBlocks } from '@/utils/api/get-blocks'
 import { getCurrentUser } from '@/utils/api/server/get-current-user'
+import { DeleteBlockButton } from './delete-block-button'
 
 type Props = {
   page: string
@@ -9,6 +10,7 @@ type Props = {
 
 const cardsLayoutClasses =
   'grid gap-4 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3'
+const buttonLayoutClasses = 'relative z-10 mt-4'
 
 export async function BlocksCards({ page }: Props) {
   const { account: currentUser } = await getCurrentUser()
@@ -27,7 +29,11 @@ export async function BlocksCards({ page }: Props) {
           name={block.blocked.name}
           bio={block.blocked.bio}
           avatarUrl={block.blocked.avatarUrl}
-        />
+        >
+          <div className={buttonLayoutClasses}>
+            <DeleteBlockButton blockId={block.id} />
+          </div>
+        </UserCard>
       ))}
     </div>
   )
@@ -37,7 +43,11 @@ export function LoadingBlocksCards() {
   return (
     <div className={cardsLayoutClasses}>
       {Array.from({ length: 18 }).map((_, index) => (
-        <LoadingUserCard key={index} />
+        <LoadingUserCard key={index}>
+          <div className={buttonLayoutClasses}>
+            <div className="skeleton shape-btn" />
+          </div>
+        </LoadingUserCard>
       ))}
     </div>
   )


### PR DESCRIPTION
### Summary

Add delete block button with confirmation modal to the blocks user list, allowing users to unblock blocked users safely with proper confirmation and error handling.

### Changes

- Add DeleteBlockButton component with confirmation modal similar to DeleteContactButton
- Implement deleteBlock Server Action for API interaction with proper error handling
- Integrate delete button into BlocksCards component with consistent styling
- Add modal confirmation dialog with warning icon and clear messaging
- Include proper authentication handling with 401 redirect support
- Implement loading states and error handling via snackbar notifications
- Add skeleton loading state for delete button in LoadingBlocksCards

### Testing

- Verified confirmation modal appears on delete button click
- Tested successful block deletion with proper page refresh
- Confirmed proper error handling for network and server errors
- Validated 401 authentication redirect functionality
- Checked modal accessibility with proper ARIA labels
- Tested loading states and disabled button during API calls

![screen-recording-96](https://github.com/user-attachments/assets/4b5d2c69-459c-4d6a-8e84-8a4556e0ecde)

### Related Issues (Optional)

Related Issues: N/A

### Notes (Optional)

This PR builds upon the blocks list foundation (#774) and completes the block management functionality by adding the ability to unblock users.