### PR TITLE
fix: improve error handling in create contact button

### DIFF
--- a/src/app/(main)/users/contacts/_components/current-user-create-contact-button/create-contact-button/use-create-contact-button.tsx
+++ b/src/app/(main)/users/contacts/_components/current-user-create-contact-button/create-contact-button/use-create-contact-button.tsx
@@ -7,8 +7,6 @@ import { useErrorSnackbar } from '@/app/_components/snackbars/snackbar/use-error
 import { useModal } from '@/components/modal/use-modal'
 import { signUpSchema } from '@/schemas/request/auth'
 import { createContact } from '@/utils/api/create-contact'
-import { createFormErrorsSchema } from '@/utils/form/create-form-errors-schema'
-import { useHandleFormErrors } from '@/utils/form/use-handle-form-error'
 import { isValidValue } from '@/utils/type-guard/is-valid-value'
 import type { ErrorObject } from '@/types/error'
 import type { HttpError } from '@/utils/error/custom/http-error'
@@ -17,13 +15,14 @@ import type { SubmitHandler } from 'react-hook-form'
 const createContactSchema = signUpSchema.pick({ email: true })
 type CreateContactFormValues = z.infer<typeof createContactSchema>
 
-const formErrorsSchema = createFormErrorsSchema(z.enum(['email']))
+const errorMessageSchema = z.object({
+  message: z.string(),
+})
+const snackbarErrorSchema = z.object({
+  error: errorMessageSchema,
+})
 const snackbarErrorsSchema = z.object({
-  errors: z.array(
-    z.object({
-      message: z.string(),
-    }),
-  ),
+  errors: z.array(errorMessageSchema),
 })
 
 type Params = {
@@ -49,14 +48,11 @@ export function useCreateContactButton({ currentUserId }: Params) {
     register,
     handleSubmit,
     reset,
-    setError,
     formState: { errors },
   } = useForm<CreateContactFormValues>({
     mode: 'onBlur',
     resolver: zodResolver(createContactSchema),
   })
-
-  const { handleFormErrors } = useHandleFormErrors(setError)
 
   const handleClose = useCallback(
     (ev: React.SyntheticEvent<HTMLDialogElement, Event>) => {
@@ -69,15 +65,15 @@ export function useCreateContactButton({ currentUserId }: Params) {
   const handleHttpError = useCallback(
     (err: ErrorObject<HttpError>) => {
       const { data } = err
-      if (isValidValue(formErrorsSchema, data)) {
-        handleFormErrors(data)
+      if (isValidValue(snackbarErrorSchema, data)) {
+        openErrorSnackbar(err, data.error.message)
       } else if (isValidValue(snackbarErrorsSchema, data)) {
         openErrorSnackbar(err, data.errors[0].message)
       } else {
         openErrorSnackbar(err)
       }
     },
-    [handleFormErrors, openErrorSnackbar],
+    [openErrorSnackbar],
   )
 
   const onSubmit: SubmitHandler<CreateContactFormValues> = useCallback(
@@ -87,6 +83,8 @@ export function useCreateContactButton({ currentUserId }: Params) {
         if (result.status === 'error') {
           if (result.name === 'HttpError') {
             handleHttpError(result)
+          } else {
+            openErrorSnackbar(result)
           }
         } else {
           reset()
@@ -95,7 +93,14 @@ export function useCreateContactButton({ currentUserId }: Params) {
         }
       })
     },
-    [currentUserId, reset, router, handleHttpError, closeModal],
+    [
+      currentUserId,
+      reset,
+      router,
+      handleHttpError,
+      openErrorSnackbar,
+      closeModal,
+    ],
   )
 
   return {


### PR DESCRIPTION
### Summary

Fixed error message display when registering users from the /users/contacts page. The contact creation form now properly displays error messages in snackbars instead of attempting to use generic form error handling.

- Before
	![screen-recording-104](https://github.com/user-attachments/assets/81a1b39b-b7cc-4e05-bb74-0ff49f2037b0)

- After	
	![screen-recording-105](https://github.com/user-attachments/assets/a412391d-aaeb-4aaf-acdd-87f98cd2ba29)

### Changes

- Replaced generic form error handling with specialized snackbar error handling in create contact button
- Removed dependencies on `createFormErrorsSchema` and `useHandleFormErrors` utilities
- Added inline error schema definitions for better type safety and clarity
- Fixed missing error message display for `snackbarErrorsSchema` case

### Testing

- Verified error messages now display properly in snackbars when contact creation fails
- Confirmed successful contact creation flow still works correctly
- All quality checks passed (ESLint, Prettier, Markuplint, Knip)

- Error
	![screen-recording-105](https://github.com/user-attachments/assets/a412391d-aaeb-4aaf-acdd-87f98cd2ba29)

- Success
	![screen-recording-107](https://github.com/user-attachments/assets/977eb144-a4db-4d4b-9fb9-6997250ca77d)

### Related Issues

N/A

### Notes

No additional information or considerations at this time.