### PR TITLE
feat: add task group detail page with modal

### DIFF
--- a/src/app/(main)/tasks/groups/[id]/_components/show-task-group-detail-modal-button/index.tsx
+++ b/src/app/(main)/tasks/groups/[id]/_components/show-task-group-detail-modal-button/index.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import { EllipsisHorizontalIcon, XMarkIcon } from '@heroicons/react/24/solid'
+import { IconButton } from '@/components/buttons/icon-button'
+import { ModalContent } from '@/components/contents/modal-content'
+import { Modal } from '@/components/modal'
+import { useModal } from '@/components/modal/use-modal'
+
+type Props = {
+  modalContent: React.ReactNode
+}
+
+export function ShowTaskGroupDetailModalButton({ modalContent }: Props) {
+  const {
+    shouldMount,
+    isOpen,
+    openModal,
+    closeModal,
+    unmountModal,
+    handleAnimationEnd,
+    handleCancel,
+  } = useModal()
+
+  return (
+    <>
+      <IconButton
+        type="button"
+        aria-label="タスクグループ詳細モーダルを開く"
+        onClick={openModal}
+      >
+        <EllipsisHorizontalIcon className="size-6 fill-black stroke-black" />
+      </IconButton>
+      {shouldMount && (
+        <Modal
+          isOpen={isOpen}
+          onAnimationEnd={handleAnimationEnd}
+          onCancel={handleCancel}
+          onClose={unmountModal}
+          onBackdropClick={handleCancel}
+        >
+          <ModalContent
+            upperLeftIcon={
+              <IconButton
+                type="button"
+                aria-label="モーダルを閉じる"
+                onClick={closeModal}
+              >
+                <XMarkIcon className="size-6" />
+              </IconButton>
+            }
+          >
+            {modalContent}
+          </ModalContent>
+        </Modal>
+      )}
+    </>
+  )
+}

--- a/src/app/(main)/tasks/groups/[id]/_components/task-group-detail/index.tsx
+++ b/src/app/(main)/tasks/groups/[id]/_components/task-group-detail/index.tsx
@@ -1,0 +1,50 @@
+import { Suspense } from 'react'
+import { DetailItemHeading } from '@/components/headings/detail-item-heading'
+import { DetailItemContentLayout } from '@/components/layouts/detail-item-content-layout'
+import { DetailItemHeadingLayout } from '@/components/layouts/detail-item-heading-layout'
+import {
+  LoadingTaskGroupDetailIcon,
+  TaskGroupDetailIcon,
+} from './task-group-detail-icon'
+import { LoadingTaskGroupName, TaskGroupName } from './task-group-name'
+import { LoadingTaskGroupNote, TaskGroupNote } from './task-group-note'
+import { TaskGroupNoteCollapsibleSection } from './task-group-note-collapsible-section'
+
+type Props = {
+  id: string
+}
+
+export function TaskGroupDetail({ id }: Props) {
+  return (
+    <div className="md:w-[40rem]">
+      <div className="flex flex-col space-y-10">
+        <DetailItemHeadingLayout>
+          <DetailItemHeading>アイコン</DetailItemHeading>
+        </DetailItemHeadingLayout>
+        <DetailItemContentLayout>
+          <Suspense fallback={<LoadingTaskGroupDetailIcon />}>
+            <TaskGroupDetailIcon id={id} />
+          </Suspense>
+        </DetailItemContentLayout>
+        <DetailItemHeadingLayout>
+          <DetailItemHeading>グループ名</DetailItemHeading>
+        </DetailItemHeadingLayout>
+        <DetailItemContentLayout>
+          <Suspense fallback={<LoadingTaskGroupName />}>
+            <TaskGroupName id={id} />
+          </Suspense>
+        </DetailItemContentLayout>
+        <DetailItemHeadingLayout>
+          <DetailItemHeading>メモ</DetailItemHeading>
+        </DetailItemHeadingLayout>
+        <TaskGroupNoteCollapsibleSection>
+          <DetailItemContentLayout>
+            <Suspense fallback={<LoadingTaskGroupNote />}>
+              <TaskGroupNote id={id} />
+            </Suspense>
+          </DetailItemContentLayout>
+        </TaskGroupNoteCollapsibleSection>
+      </div>
+    </div>
+  )
+}

--- a/src/app/(main)/tasks/groups/[id]/_components/task-group-detail/task-group-detail-icon/index.tsx
+++ b/src/app/(main)/tasks/groups/[id]/_components/task-group-detail/task-group-detail-icon/index.tsx
@@ -1,0 +1,16 @@
+import { getTaskGroup } from '@/utils/api/get-task-group'
+import { TaskGroupDetailEmoji } from './task-group-detail-emoji'
+
+type Props = {
+  id: string
+}
+
+export async function TaskGroupDetailIcon({ id }: Props) {
+  const { taskGroup } = await getTaskGroup(id)
+
+  return <TaskGroupDetailEmoji unified={taskGroup.icon} />
+}
+
+export function LoadingTaskGroupDetailIcon() {
+  return <span className="skeleton block size-6 rounded-sm" />
+}

--- a/src/app/(main)/tasks/groups/[id]/_components/task-group-detail/task-group-detail-icon/task-group-detail-emoji/index.tsx
+++ b/src/app/(main)/tasks/groups/[id]/_components/task-group-detail/task-group-detail-icon/task-group-detail-emoji/index.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+
+const iconSize = 24
+
+const Emoji = dynamic(
+  () => import('emoji-picker-react').then((mod) => mod.Emoji),
+  {
+    loading: () => (
+      <span
+        className={`skeleton block rounded-sm`}
+        style={{ height: `${iconSize}px`, width: `${iconSize}px` }}
+      />
+    ),
+    ssr: false,
+  },
+)
+
+type Props = {
+  unified: string
+}
+
+export function TaskGroupDetailEmoji({ unified }: Props) {
+  return <Emoji unified={unified} size={iconSize} />
+}

--- a/src/app/(main)/tasks/groups/[id]/_components/task-group-detail/task-group-name/index.tsx
+++ b/src/app/(main)/tasks/groups/[id]/_components/task-group-detail/task-group-name/index.tsx
@@ -1,0 +1,19 @@
+import {
+  DetailSingleLineText,
+  LoadingDetailSingleLineText,
+} from '@/components/texts/detail-single-line-text'
+import { getTaskGroup } from '@/utils/api/get-task-group'
+
+type Props = {
+  id: string
+}
+
+export async function TaskGroupName({ id }: Props) {
+  const { taskGroup } = await getTaskGroup(id)
+
+  return <DetailSingleLineText>{taskGroup.name}</DetailSingleLineText>
+}
+
+export function LoadingTaskGroupName() {
+  return <LoadingDetailSingleLineText />
+}

--- a/src/app/(main)/tasks/groups/[id]/_components/task-group-detail/task-group-note-collapsible-section/index.tsx
+++ b/src/app/(main)/tasks/groups/[id]/_components/task-group-detail/task-group-note-collapsible-section/index.tsx
@@ -1,0 +1,11 @@
+'use client'
+
+import { CollapsibleSection } from '@/components/collapsible-sections/collapsible-section'
+
+type Props = {
+  children: React.ReactNode
+}
+
+export function TaskGroupNoteCollapsibleSection({ children }: Props) {
+  return <CollapsibleSection minHeight={160}>{children}</CollapsibleSection>
+}

--- a/src/app/(main)/tasks/groups/[id]/_components/task-group-detail/task-group-note/index.tsx
+++ b/src/app/(main)/tasks/groups/[id]/_components/task-group-detail/task-group-note/index.tsx
@@ -1,0 +1,27 @@
+import {
+  DetailMultiLineText,
+  LoadingDetailMultiLineText,
+} from '@/components/texts/detail-multi-line-text'
+import { getTaskGroup } from '@/utils/api/get-task-group'
+
+type Props = {
+  id: string
+}
+
+export async function TaskGroupNote({ id }: Props) {
+  const { taskGroup } = await getTaskGroup(id)
+
+  return (
+    <div>
+      {taskGroup.note === undefined || taskGroup.note === '' ? (
+        <p className="text-gray-500">メモを登録できます...</p>
+      ) : (
+        <DetailMultiLineText>{taskGroup.note}</DetailMultiLineText>
+      )}
+    </div>
+  )
+}
+
+export function LoadingTaskGroupNote() {
+  return <LoadingDetailMultiLineText lines={6} />
+}

--- a/src/app/(main)/tasks/groups/[id]/_components/task-group-header-icon/index.tsx
+++ b/src/app/(main)/tasks/groups/[id]/_components/task-group-header-icon/index.tsx
@@ -1,0 +1,16 @@
+import { getTaskGroup } from '@/utils/api/get-task-group'
+import { TaskGroupHeaderEmoji } from './task-group-header-emoji'
+
+type Props = {
+  id: string
+}
+
+export async function TaskGroupHeaderIcon({ id }: Props) {
+  const { taskGroup } = await getTaskGroup(id)
+
+  return <TaskGroupHeaderEmoji unified={taskGroup.icon} />
+}
+
+export function LoadingTaskGroupHeaderIcon() {
+  return <span className="skeleton block size-7 rounded-sm" />
+}

--- a/src/app/(main)/tasks/groups/[id]/_components/task-group-header-icon/task-group-header-emoji/index.tsx
+++ b/src/app/(main)/tasks/groups/[id]/_components/task-group-header-icon/task-group-header-emoji/index.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+
+const iconSize = 28
+
+const Emoji = dynamic(
+  () => import('emoji-picker-react').then((mod) => mod.Emoji),
+  {
+    loading: () => (
+      <span
+        className={`skeleton block rounded-sm`}
+        style={{ height: `${iconSize}px`, width: `${iconSize}px` }}
+      />
+    ),
+    ssr: false,
+  },
+)
+
+type Props = {
+  unified: string
+}
+
+export function TaskGroupHeaderEmoji({ unified }: Props) {
+  return <Emoji unified={unified} size={iconSize} />
+}

--- a/src/app/(main)/tasks/groups/[id]/_components/task-group-heading/index.tsx
+++ b/src/app/(main)/tasks/groups/[id]/_components/task-group-heading/index.tsx
@@ -1,0 +1,15 @@
+import { getTaskGroup } from '@/utils/api/get-task-group'
+
+type Props = {
+  id: string
+}
+
+export async function TaskGroupHeading({ id }: Props) {
+  const { taskGroup } = await getTaskGroup(id)
+
+  return <h1 className="truncate text-2xl font-bold">{taskGroup.name}</h1>
+}
+
+export function LoadingTaskGroupHeading() {
+  return <span className="skeleton my-1 block h-6 w-60 rounded-md" />
+}

--- a/src/app/(main)/tasks/groups/[id]/error.tsx
+++ b/src/app/(main)/tasks/groups/[id]/error.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import { Button } from '@/components/buttons/button'
+import { ErrorContent } from '@/components/contents/error-content'
+import { IconMessage } from '@/components/icon-message'
+import { ReportIssueLink } from '@/components/links/report-issue-link'
+import type { ErrorProps } from '@/types/error'
+
+export default function Error({ error, reset }: ErrorProps) {
+  return (
+    <div className="mt-10 md:mt-20">
+      <IconMessage severity="error" title="Error">
+        <ErrorContent
+          message="タスクグループ詳細画面の表示中に問題が発生しました。"
+          resetButton={
+            <Button type="button" className="btn-success" onClick={reset}>
+              再読み込み
+            </Button>
+          }
+          reportIssueLink={<ReportIssueLink info={`Digest: ${error.digest}`} />}
+        />
+      </IconMessage>
+    </div>
+  )
+}

--- a/src/app/(main)/tasks/groups/[id]/loading.tsx
+++ b/src/app/(main)/tasks/groups/[id]/loading.tsx
@@ -1,0 +1,5 @@
+import { LoadingPage } from '@/components/pages/loading-page'
+
+export default function Loading() {
+  return <LoadingPage pageTitle="タスクグループ詳細" />
+}

--- a/src/app/(main)/tasks/groups/[id]/not-found.tsx
+++ b/src/app/(main)/tasks/groups/[id]/not-found.tsx
@@ -1,0 +1,12 @@
+import { NotFoundContent } from '@/components/contents/not-found-content'
+import { IconMessage } from '@/components/icon-message'
+
+export default function NotFound() {
+  return (
+    <div className="mt-40">
+      <IconMessage severity="error" title="Not Found">
+        <NotFoundContent message="タスクグループが見つかりませんでした。" />
+      </IconMessage>
+    </div>
+  )
+}

--- a/src/app/(main)/tasks/groups/[id]/page.tsx
+++ b/src/app/(main)/tasks/groups/[id]/page.tsx
@@ -1,3 +1,41 @@
-export default function TaskGroups() {
-  return <div>タスクグループ詳細</div>
+import { Suspense } from 'react'
+import { ShowTaskGroupDetailModalButton } from './_components/show-task-group-detail-modal-button'
+import { TaskGroupDetail } from './_components/task-group-detail'
+import {
+  LoadingTaskGroupHeaderIcon,
+  TaskGroupHeaderIcon,
+} from './_components/task-group-header-icon'
+import {
+  LoadingTaskGroupHeading,
+  TaskGroupHeading,
+} from './_components/task-group-heading'
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'タスクグループ詳細',
+}
+
+type Props = {
+  params: Promise<{ id: string }>
+}
+
+export default async function TaskGroup(props: Props) {
+  const params = await props.params
+  const { id } = params
+
+  return (
+    <div className="flex items-center justify-between gap-x-5">
+      <div className="flex min-w-0 items-center gap-x-3">
+        <Suspense fallback={<LoadingTaskGroupHeaderIcon />}>
+          <TaskGroupHeaderIcon id={id} />
+        </Suspense>
+        <Suspense fallback={<LoadingTaskGroupHeading />}>
+          <TaskGroupHeading id={id} />
+        </Suspense>
+      </div>
+      <ShowTaskGroupDetailModalButton
+        modalContent={<TaskGroupDetail id={id} />}
+      />
+    </div>
+  )
 }

--- a/src/schemas/response/task-group.ts
+++ b/src/schemas/response/task-group.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod'
+
+export const taskGroupSchema = z.object({
+  task_group: z.object({
+    id: z.number(),
+    name: z.string(),
+    icon: z.string(),
+    note: z.string().optional(),
+  }),
+})

--- a/src/utils/api/get-task-group.ts
+++ b/src/utils/api/get-task-group.ts
@@ -1,0 +1,52 @@
+import 'server-only'
+import camelcaseKeys from 'camelcase-keys'
+import { notFound, redirect } from 'next/navigation'
+import { cache } from 'react'
+import { taskGroupSchema } from '@/schemas/response/task-group'
+import { getBearerToken } from '@/utils/cookie/bearer-token'
+import { HttpError } from '@/utils/error/custom/http-error'
+import { generateRedirectLoginPath } from '@/utils/login-path/generate-redirect-login-path.server'
+import { fetchData } from './fetch-data'
+import { getRequestId } from '../request-id/get-request-id'
+import { validateData } from '../validation/validate-data'
+
+export const getTaskGroup = cache(async (id: string) => {
+  const fetchDataResult = await fetchData(
+    `${process.env.API_ORIGIN}/api/v1/task_groups/${id}`,
+    {
+      method: 'GET',
+      headers: {
+        Authorization: await getBearerToken(),
+      },
+    },
+  )
+
+  if (fetchDataResult instanceof Error) {
+    const isHttpError = fetchDataResult instanceof HttpError
+    const isUnauthorized = isHttpError && fetchDataResult.statusCode === 401
+    const isNotFound = isHttpError && fetchDataResult.statusCode === 404
+    if (isUnauthorized) {
+      const redirectLoginPath = await generateRedirectLoginPath()
+      redirect(redirectLoginPath)
+    }
+    if (isNotFound) {
+      notFound()
+    }
+    throw fetchDataResult
+  }
+
+  const { headers, data } = fetchDataResult
+  const requestId = getRequestId(headers)
+
+  const validateDataResult = validateData({
+    requestId,
+    dataSchema: taskGroupSchema,
+    data,
+  })
+  if (validateDataResult instanceof Error) {
+    throw validateDataResult
+  }
+
+  const camelcaseData = camelcaseKeys(validateDataResult, { deep: true })
+  return camelcaseData
+})


### PR DESCRIPTION
### Summary

Add task group detail page with modal functionality. The page displays task group icon and name in the header, with a button to open a detailed modal showing complete task group information.

### Changes

- Implement task group detail page at `/tasks/groups/[id]`
- Add server components with independent data fetching pattern:
  - `TaskGroupHeaderIcon`: Displays group icon in header
  - `TaskGroupHeading`: Displays group name in header
  - `TaskGroupDetail`: Modal content with icon, name, and note
  - `TaskGroupDetailIcon`: Displays group icon in detail modal
  - `TaskGroupName`: Group name in detail modal
  - `TaskGroupNote`: Group note in detail modal with collapsible section
- Add `ShowTaskGroupDetailModalButton` to trigger detail modal
- Implement `getTaskGroup` API utility with error handling and validation
- Add `taskGroupSchema` for response validation using Zod
- Add loading states with Suspense for each component
- Add error boundary and not-found pages for task group routes

### Testing

Tested manually in development environment:
- Verified task group detail page renders correctly
- Confirmed each component loads independently with proper loading states
- Validated error handling for unauthorized and not-found cases
- Checked modal opens and displays complete task group information

![screen-recording-112](https://github.com/user-attachments/assets/a0774a71-dde5-4d53-985f-6d1c47bda714)

![screen-recording-113](https://github.com/user-attachments/assets/69b64c19-9c5e-4f41-8ca7-d1852e1c0873)

<img width="2730" height="1808" alt="screen-shot-677" src="https://github.com/user-attachments/assets/8651259c-5aaa-4622-81b0-5dfee8395828" />

### Related Issues

N/A

### Notes

No additional information or considerations at this time.