### PR TITLE
feat: add task group delete functionality

### DIFF
--- a/src/app/(main)/tasks/groups/[id]/_components/task-group-detail/delete-task-group-button/delete-task-group.api.ts
+++ b/src/app/(main)/tasks/groups/[id]/_components/task-group-detail/delete-task-group-button/delete-task-group.api.ts
@@ -1,0 +1,48 @@
+'use server'
+
+import { z } from 'zod'
+import { ResultObject } from '@/types/api'
+import { fetchData } from '@/utils/api/fetch-data'
+import { getBearerToken } from '@/utils/cookie/bearer-token'
+import { createErrorObject } from '@/utils/error/create-error-object'
+import { getRequestId } from '@/utils/request-id/get-request-id'
+import { validateData } from '@/utils/validation/validate-data'
+
+const dataSchema = z.null()
+
+type Data = z.infer<typeof dataSchema>
+
+type Params = {
+  taskGroupId: string
+}
+
+export async function deleteTaskGroup({ taskGroupId }: Params) {
+  const fetchDataResult = await fetchData(
+    `${process.env.API_ORIGIN}/api/v1/task_groups/${taskGroupId}`,
+    {
+      method: 'DELETE',
+      headers: {
+        Authorization: await getBearerToken(),
+      },
+    },
+  )
+
+  let resultObject: ResultObject<Data>
+
+  if (fetchDataResult instanceof Error) {
+    resultObject = createErrorObject(fetchDataResult)
+  } else {
+    const { headers, data } = fetchDataResult
+    const requestId = getRequestId(headers)
+
+    const validateDataResult = validateData({ requestId, dataSchema, data })
+
+    if (validateDataResult instanceof Error) {
+      resultObject = createErrorObject(validateDataResult)
+    } else {
+      resultObject = { status: 'success' }
+    }
+  }
+
+  return resultObject
+}

--- a/src/app/(main)/tasks/groups/[id]/_components/task-group-detail/delete-task-group-button/index.tsx
+++ b/src/app/(main)/tasks/groups/[id]/_components/task-group-detail/delete-task-group-button/index.tsx
@@ -1,0 +1,115 @@
+'use client'
+
+import { XMarkIcon } from '@heroicons/react/24/solid'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useTransition } from 'react'
+import { useErrorSnackbar } from '@/app/_components/snackbars/snackbar/use-error-snackbar'
+import { Button } from '@/components/buttons/button'
+import { IconButton } from '@/components/buttons/icon-button'
+import { ModalContent } from '@/components/contents/modal-content'
+import { IconMessage } from '@/components/icon-message'
+import { Modal } from '@/components/modal'
+import { useModal } from '@/components/modal/use-modal'
+import { useRedirectLoginPath } from '@/utils/login-path/use-redirect-login-path'
+import { deleteTaskGroup } from './delete-task-group.api'
+
+type Props = {
+  taskGroupId: string
+}
+
+export function DeleteTaskGroupButton({ taskGroupId }: Props) {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const redirectLoginPath = useRedirectLoginPath({ searchParams })
+  const [isPending, startTransition] = useTransition()
+  const { openErrorSnackbar } = useErrorSnackbar()
+  const {
+    shouldMount,
+    isOpen,
+    openModal,
+    closeModal,
+    unmountModal,
+    handleAnimationEnd,
+    handleCancel,
+  } = useModal()
+
+  const handleOkClick = () => {
+    closeModal()
+    startTransition(async () => {
+      const result = await deleteTaskGroup({ taskGroupId })
+      if (result.status === 'error') {
+        if (result.name === 'HttpError' && result.statusCode === 401) {
+          router.push(redirectLoginPath)
+        } else {
+          openErrorSnackbar(result)
+        }
+      } else {
+        router.replace('/tasks')
+      }
+    })
+  }
+
+  const handleClose = (ev: React.SyntheticEvent<HTMLDialogElement, Event>) => {
+    ev.stopPropagation()
+    unmountModal()
+  }
+
+  return (
+    <>
+      <Button
+        type="button"
+        className="btn-danger"
+        status={isPending ? 'pending' : 'idle'}
+        onClick={openModal}
+      >
+        削除
+      </Button>
+      {shouldMount && (
+        <Modal
+          isOpen={isOpen}
+          onAnimationEnd={handleAnimationEnd}
+          onCancel={handleCancel}
+          onClose={handleClose}
+          onBackdropClick={closeModal}
+        >
+          <ModalContent
+            upperLeftIcon={
+              <IconButton
+                type="button"
+                aria-label="モーダルを閉じる"
+                onClick={closeModal}
+              >
+                <XMarkIcon className="size-6" />
+              </IconButton>
+            }
+          >
+            <IconMessage severity="warning" title="確認">
+              <p className="mb-5 sm:text-center">
+                本当にこのタスクグループを削除しますか？
+                <br />
+                削除すると、タスクグループ内のすべてのタスクも削除されます。
+              </p>
+              <div className="mx-2.5 flex items-center justify-center gap-5">
+                <Button
+                  type="button"
+                  className="btn-danger"
+                  status={isPending ? 'disabled' : 'idle'}
+                  onClick={handleOkClick}
+                >
+                  削除
+                </Button>
+                <Button
+                  type="button"
+                  className="btn-ghost"
+                  onClick={closeModal}
+                >
+                  キャンセル
+                </Button>
+              </div>
+            </IconMessage>
+          </ModalContent>
+        </Modal>
+      )}
+    </>
+  )
+}

--- a/src/app/(main)/tasks/groups/[id]/_components/task-group-detail/index.tsx
+++ b/src/app/(main)/tasks/groups/[id]/_components/task-group-detail/index.tsx
@@ -1,4 +1,7 @@
 import { Suspense } from 'react'
+import { HorizontalRule } from '@/components/horizontal-rule'
+import { DetailItemContentLayout } from '@/components/layouts/detail-item-content-layout'
+import { DeleteTaskGroupButton } from './delete-task-group-button'
 import {
   EditableTaskGroupIcon,
   LoadingEditableTaskGroupIcon,
@@ -29,6 +32,10 @@ export function TaskGroupDetail({ id }: Props) {
         <Suspense fallback={<LoadingEditableTaskGroupNote />}>
           <EditableTaskGroupNote taskGroupId={id} />
         </Suspense>
+        <HorizontalRule />
+        <DetailItemContentLayout>
+          <DeleteTaskGroupButton taskGroupId={id} />
+        </DetailItemContentLayout>
       </div>
     </div>
   )


### PR DESCRIPTION
### Summary

Add delete functionality to task groups with confirmation modal. Users can now delete task groups from the detail page, with proper error handling and navigation.

### Changes

- Create `DeleteTaskGroupButton` component with modal confirmation dialog
- Implement `deleteTaskGroup` server action to call DELETE `/api/v1/task_groups/:id` endpoint
- Integrate delete button into `TaskGroupDetail` layout with horizontal rule separator
- Use `router.replace` to redirect to `/tasks` after successful deletion
- Add proper error handling for 401 authentication errors and other failures

### Testing

- Verified delete button appears in TaskGroupDetail
- Confirmed modal confirmation dialog displays correct warning message
- Tested successful deletion redirects to `/tasks` page
- Verified error handling for authentication failures
- Ensured ESLint, Prettier, and all quality checks pass

![screen-recording-120](https://github.com/user-attachments/assets/40a57cbc-d42c-4278-bdd2-4167f564b1a7)

### Related Issues (Optional)

N/A

### Notes (Optional)

No additional information or considerations at this time.