### PR TITLE
fix: use getFieldState for type-safe field error retrieval

### DIFF
--- a/src/components/editable-text/use-editable-text.tsx
+++ b/src/components/editable-text/use-editable-text.tsx
@@ -30,7 +30,8 @@ export function useEditableText<T extends FieldValues>({
     getValues,
     setValue,
     setError,
-    formState: { isDirty, isValid, isSubmitting, errors },
+    getFieldState,
+    formState: { isDirty, isValid, isSubmitting },
   } = useForm({
     mode: 'onChange',
     shouldFocusError: false,
@@ -157,7 +158,7 @@ export function useEditableText<T extends FieldValues>({
     hasLocalStorageValue,
     isSubmitting,
     registerReturn: register(name),
-    fieldError: errors[name],
+    fieldError: getFieldState(name).error,
     closeEditor,
     openEditor,
     handleFormErrors,


### PR DESCRIPTION
### Summary

Fix TypeScript type error in `useEditableText` hook by using `getFieldState()` method instead of direct `errors[name]` access for type-safe field error retrieval.

### Changes

- Modified `useEditableText` hook in `src/components/editable-text/use-editable-text.tsx`
  - Added `getFieldState` to destructured values from `useForm()`
  - Removed `errors` from `formState` destructuring (no longer needed)
  - Changed `fieldError` assignment from `errors[name]` to `getFieldState(name).error`

The `errors[name]` type is `FieldError | Merge<FieldError, FieldErrorsImpl<any>> | undefined` for nested object support, but form control components expect `FieldError | undefined`. Using `getFieldState(name).error` provides the correct type as documented in React Hook Form official API.

### Testing

- TypeScript type checking passed (`yarn tsc --noEmit`)
- ESLint validation passed (`yarn lint-fix`)
- All Lefthook pre-commit checks passed
- Verified error messages display correctly in forms using `useEditableText`
	- `/tasks/groups/1` task group name
		<img width="2722" height="1800" alt="screen-shot-706" src="https://github.com/user-attachments/assets/82fa8533-43e6-4c4c-9d30-7de502d91cc5" />
	- `/tasks/groups/1` task group note
		<img width="2722" height="1800" alt="screen-shot-707" src="https://github.com/user-attachments/assets/529caf05-3498-4f57-9f07-e0c1cbb30ba0" />
	- `/account` user name
		<img width="2722" height="1800" alt="screen-shot-708" src="https://github.com/user-attachments/assets/b321e79d-fa3f-44dc-864c-511289e6a324" />
	- `/account` bio
		<img width="2722" height="1800" alt="screen-shot-709" src="https://github.com/user-attachments/assets/30e03d2b-962c-4a6b-ab38-bba01cc8eb2e" />
	- `/account` email
		<img width="2722" height="1800" alt="screen-shot-710" src="https://github.com/user-attachments/assets/76018508-a760-48d7-9396-a603a3f870d3" />
	- `/users/profile/94` desplay name
		<img width="2722" height="1800" alt="screen-shot-711" src="https://github.com/user-attachments/assets/0ac8e006-3da6-406b-8a29-e81239ed64ef" />
	- `/users/profile/94` contact note
		<img width="2722" height="1800" alt="screen-shot-712" src="https://github.com/user-attachments/assets/bee6e706-29ce-4f8b-8c7f-96ded1396d6b" />

### Related Issues (Optional)

N/A

### Notes (Optional)

No additional information or considerations at this time.