### PR TITLE
fix: ensure smooth modal opening with emoji picker

### DIFF
--- a/src/app/(main)/tasks/_components/tasks-sidebar-content/create-task-group-button/create-task-group-form/index.tsx
+++ b/src/app/(main)/tasks/_components/tasks-sidebar-content/create-task-group-button/create-task-group-form/index.tsx
@@ -1,5 +1,4 @@
 import dynamic from 'next/dynamic'
-import { useId } from 'react'
 import { Button } from '@/components/buttons/button'
 import { Label } from '@/components/form-controls/label'
 import { TextArea } from '@/components/form-controls/text-area'
@@ -18,9 +17,8 @@ type Props = {
 }
 
 export function CreateTaskGroupForm({ handleSubmitSuccess }: Props) {
-  const popoverId = useId()
-
   const {
+    popoverId,
     popoverRef,
     register,
     handleSubmit,
@@ -31,7 +29,9 @@ export function CreateTaskGroupForm({ handleSubmitSuccess }: Props) {
     shadowRef,
     wordCount,
     handleNoteInput,
+    handleButtonClick,
     handleEmojiClick,
+    shouldPickerMount,
     watch,
   } = useCreateTaskGroupForm({ handleSubmitSuccess })
 
@@ -41,6 +41,7 @@ export function CreateTaskGroupForm({ handleSubmitSuccess }: Props) {
       <button
         type="button"
         className={`text-box size-11 ${errors.icon === undefined ? '' : 'text-box-error'}`}
+        onClick={handleButtonClick}
         popoverTarget={popoverId}
       >
         <Emoji unified={watch('icon')} size={32} />
@@ -51,13 +52,15 @@ export function CreateTaskGroupForm({ handleSubmitSuccess }: Props) {
         id={popoverId}
         className="top-[anchor(top)] left-[anchor(right)] ml-1 rounded-lg drop-shadow-md"
       >
-        <Picker
-          onEmojiClick={handleEmojiClick}
-          searchDisabled={true}
-          skinTonesDisabled={true}
-          previewConfig={{ showPreview: false }}
-          width="100%"
-        />
+        {shouldPickerMount && (
+          <Picker
+            onEmojiClick={handleEmojiClick}
+            searchDisabled={true}
+            skinTonesDisabled={true}
+            previewConfig={{ showPreview: false }}
+            width="100%"
+          />
+        )}
       </div>
       <TextField
         type="text"

--- a/src/app/(main)/tasks/_components/tasks-sidebar-content/create-task-group-button/create-task-group-form/use-create-task-group-form.tsx
+++ b/src/app/(main)/tasks/_components/tasks-sidebar-content/create-task-group-button/create-task-group-form/use-create-task-group-form.tsx
@@ -1,6 +1,6 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useRouter } from 'next/navigation'
-import { useCallback, useRef, useTransition } from 'react'
+import { useCallback, useId, useRef, useState, useTransition } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 import { useErrorSnackbar } from '@/app/_components/snackbars/snackbar/use-error-snackbar'
@@ -35,10 +35,12 @@ type Params = {
 }
 
 export function useCreateTaskGroupForm({ handleSubmitSuccess }: Params) {
+  const popoverId = useId()
   const popoverRef = useRef<HTMLDivElement>(null)
   const noteEditorRef = useRef<HTMLTextAreaElement>(null)
   const router = useRouter()
   const [isPending, startTransition] = useTransition()
+  const [shouldPickerMount, setShouldPickerMount] = useState(false)
   const { openErrorSnackbar } = useErrorSnackbar()
 
   const {
@@ -64,6 +66,12 @@ export function useCreateTaskGroupForm({ handleSubmitSuccess }: Params) {
     },
     [adjustHeight, updateWordCount],
   )
+
+  const handleButtonClick = useCallback(() => {
+    if (!shouldPickerMount) {
+      setShouldPickerMount(true)
+    }
+  }, [shouldPickerMount])
 
   const handleEmojiClick = useCallback(
     (emojiData: EmojiClickData) => {
@@ -101,6 +109,7 @@ export function useCreateTaskGroupForm({ handleSubmitSuccess }: Params) {
   )
 
   return {
+    popoverId,
     popoverRef,
     register,
     handleSubmit,
@@ -112,6 +121,8 @@ export function useCreateTaskGroupForm({ handleSubmitSuccess }: Params) {
     shadowRef,
     wordCount,
     handleNoteInput,
+    handleButtonClick,
     handleEmojiClick,
+    shouldPickerMount,
   }
 }

--- a/src/app/(main)/tasks/groups/[id]/_components/task-group-detail/task-group-detail-icon/editable-task-group-icon/task-group-icon-editor/index.tsx
+++ b/src/app/(main)/tasks/groups/[id]/_components/task-group-detail/task-group-detail-icon/editable-task-group-icon/task-group-icon-editor/index.tsx
@@ -2,7 +2,7 @@
 
 import dynamic from 'next/dynamic'
 import { useRouter, useSearchParams } from 'next/navigation'
-import { useId, useRef, useTransition } from 'react'
+import { useId, useRef, useState, useTransition } from 'react'
 import { useErrorSnackbar } from '@/app/_components/snackbars/snackbar/use-error-snackbar'
 import { DetailItemContentLayout } from '@/components/layouts/detail-item-content-layout'
 import { DetailItemHeadingLayout } from '@/components/layouts/detail-item-heading-layout'
@@ -24,10 +24,17 @@ export function TaskGroupIconEditor({ taskGroupId, label, children }: Props) {
   const popoverId = useId()
   const popoverRef = useRef<HTMLDivElement>(null)
   const [isPending, startTransition] = useTransition()
+  const [shouldPickerMount, setShouldPickerMount] = useState(false)
   const router = useRouter()
   const searchParams = useSearchParams()
   const redirectLoginPath = useRedirectLoginPath({ searchParams })
   const { openErrorSnackbar } = useErrorSnackbar()
+
+  const handleButtonClick = () => {
+    if (!shouldPickerMount) {
+      setShouldPickerMount(true)
+    }
+  }
 
   const handleHttpError = (err: ErrorObject<HttpError>) => {
     if (err.statusCode === 401) {
@@ -61,6 +68,7 @@ export function TaskGroupIconEditor({ taskGroupId, label, children }: Props) {
         <button
           type="button"
           className="block duration-200 hover:brightness-75 disabled:animate-pulse disabled:cursor-not-allowed"
+          onClick={handleButtonClick}
           popoverTarget={popoverId}
           disabled={isPending}
         >
@@ -73,13 +81,15 @@ export function TaskGroupIconEditor({ taskGroupId, label, children }: Props) {
         id={popoverId}
         className="top-[anchor(top)] left-[anchor(right)] ml-1 rounded-lg drop-shadow-md"
       >
-        <Picker
-          onEmojiClick={handleEmojiClick}
-          searchDisabled={true}
-          skinTonesDisabled={true}
-          previewConfig={{ showPreview: false }}
-          width="100%"
-        />
+        {shouldPickerMount && (
+          <Picker
+            onEmojiClick={handleEmojiClick}
+            searchDisabled={true}
+            skinTonesDisabled={true}
+            previewConfig={{ showPreview: false }}
+            width="100%"
+          />
+        )}
       </div>
     </div>
   )


### PR DESCRIPTION
### Summary

Fix modal opening animation not being displayed when using emoji picker component. The heavy emoji picker was blocking render during modal open, preventing smooth animation.

- Before
	![screen-recording-121](https://github.com/user-attachments/assets/8e245ebe-65c6-4c84-add1-87864b343752)

### Changes

Implement conditional rendering for emoji picker component to ensure smooth modal opening animation:

- Mount emoji Picker only when popover is first opened, not during initial modal render
- Keep Picker mounted after first render to maintain interaction performance
- Apply consistent optimization pattern across both TaskGroupIconEditor and CreateTaskGroupForm components

### Testing

Manually tested modal opening behavior:

- Verified smooth modal opening animation is now displayed
- Confirmed emoji picker functionality works correctly after optimization
- Tested both TaskGroupIconEditor and CreateTaskGroupForm components
- Verified no regressions in existing functionality

- `/tasks/groups/15`
	![screen-recording-122](https://github.com/user-attachments/assets/3bb187a2-c263-4b5e-8a77-088724fbeb91)

- create task group form
	![screen-recording-123](https://github.com/user-attachments/assets/6ce23f4e-6c81-444d-9c37-64107add0d96)

### Related Issues

N/A

### Notes

No additional information or considerations at this time.