### PR TITLE
feat: add task list display to task group detail page

### DIFF
--- a/src/app/(main)/tasks/groups/[id]/page.tsx
+++ b/src/app/(main)/tasks/groups/[id]/page.tsx
@@ -1,4 +1,7 @@
 import { Suspense } from 'react'
+import { TaskListLayout } from '@/components/layouts/task-list-layout'
+import TasksLayout from '@/components/layouts/tasks-layout'
+import { LoadingTaskList, TaskList } from '@/components/task-list'
 import { ShowTaskGroupDetailModalButton } from './_components/show-task-group-detail-modal-button'
 import { TaskGroupDetail } from './_components/task-group-detail'
 import {
@@ -17,25 +20,37 @@ export const metadata: Metadata = {
 
 type Props = {
   params: Promise<{ id: string }>
+  searchParams: Promise<{
+    page?: string
+  }>
 }
 
 export default async function TaskGroup(props: Props) {
   const params = await props.params
   const { id } = params
+  const searchParams = await props.searchParams
+  const { page = '1' } = searchParams
 
   return (
-    <div className="flex items-center justify-between gap-x-5">
-      <div className="flex min-w-0 items-center gap-x-3">
-        <Suspense fallback={<LoadingTaskGroupHeaderIcon />}>
-          <TaskGroupHeaderIcon id={id} />
-        </Suspense>
-        <Suspense fallback={<LoadingTaskGroupHeading />}>
-          <TaskGroupHeading id={id} />
-        </Suspense>
+    <TasksLayout>
+      <div className="flex items-center justify-between gap-x-5">
+        <div className="flex min-w-0 items-center gap-x-3">
+          <Suspense fallback={<LoadingTaskGroupHeaderIcon />}>
+            <TaskGroupHeaderIcon id={id} />
+          </Suspense>
+          <Suspense fallback={<LoadingTaskGroupHeading />}>
+            <TaskGroupHeading id={id} />
+          </Suspense>
+        </div>
+        <ShowTaskGroupDetailModalButton
+          modalContent={<TaskGroupDetail id={id} />}
+        />
       </div>
-      <ShowTaskGroupDetailModalButton
-        modalContent={<TaskGroupDetail id={id} />}
-      />
-    </div>
+      <TaskListLayout>
+        <Suspense fallback={<LoadingTaskList />}>
+          <TaskList page={page} taskGroupId={id} />
+        </Suspense>
+      </TaskListLayout>
+    </TasksLayout>
   )
 }

--- a/src/components/task-list/index.tsx
+++ b/src/components/task-list/index.tsx
@@ -5,12 +5,18 @@ import { TaskCardsContainer } from './task-cards-container'
 type Props = {
   page: string
   filter?: 'actionable'
+  taskGroupId?: string
 }
 
 const containerShapeClasses = 'h-full w-full rounded-md md:w-96'
 
-export async function TaskList({ page, filter }: Props) {
-  const { tasks, pagination } = await getTasks({ page, limit: '10', filter })
+export async function TaskList({ page, filter, taskGroupId }: Props) {
+  const { tasks, pagination } = await getTasks({
+    page,
+    limit: '10',
+    filter,
+    taskGroupId,
+  })
 
   return (
     <TaskCardsContainer

--- a/src/components/task-list/task-cards/index.tsx
+++ b/src/components/task-list/task-cards/index.tsx
@@ -4,7 +4,7 @@ import { TaskCardTaskGroupLink } from './task-card-task-group-link'
 type Props = {
   tasks: Array<
     React.ComponentProps<typeof TaskCard> & {
-      taskGroup: React.ComponentProps<typeof TaskCardTaskGroupLink>
+      taskGroup?: React.ComponentProps<typeof TaskCardTaskGroupLink>
     }
   >
 }
@@ -14,13 +14,15 @@ export function TaskCards({ tasks }: Props) {
     <div className="flex flex-col gap-2 md:gap-3">
       {tasks.map((task) => (
         <TaskCard key={task.id} {...task}>
-          <div className="relative z-10 mt-3">
-            <TaskCardTaskGroupLink
-              id={task.taskGroup.id}
-              name={task.taskGroup.name}
-              icon={task.taskGroup.icon}
-            />
-          </div>
+          {task.taskGroup !== undefined && (
+            <div className="relative z-10 mt-3">
+              <TaskCardTaskGroupLink
+                id={task.taskGroup.id}
+                name={task.taskGroup.name}
+                icon={task.taskGroup.icon}
+              />
+            </div>
+          )}
         </TaskCard>
       ))}
     </div>

--- a/src/schemas/response/tasks.ts
+++ b/src/schemas/response/tasks.ts
@@ -11,6 +11,6 @@ export const taskSchema = z.object({
     estimated_minutes: z.number().optional(),
     note: z.string().optional(),
     status: z.enum(['not_started', 'in_progress', 'completed']),
-    task_group: taskGroupSchema.shape.task_group,
+    task_group: taskGroupSchema.shape.task_group.optional(),
   }),
 })


### PR DESCRIPTION
### Summary

Add task list display to task group detail page to show all tasks belonging to the selected task group with pagination support.

### Changes

- Add `TaskList` and `TaskListLayout` components to task group detail page
- Extend `getTasks` API function to support filtering by `taskGroupId` parameter
- Make `taskGroup` field optional in task response schema for group-specific views
- Update `TaskCards` component to conditionally render task group link when viewing tasks within a group context
- Integrate existing pagination and scroll-trigger functionality for task group task lists

### Testing

- Verified task list displays correctly on task group detail page
- Confirmed pagination works properly with task group filtering
- Tested that task group links are hidden when viewing tasks within the group itself
- Validated API parameter handling for taskGroupId filtering

<img width="2878" height="1564" alt="screen-shot-751" src="https://github.com/user-attachments/assets/9052cc89-ef62-442d-a911-59039e89317a" />

### Related Issues

N/A

### Notes

This implementation reuses the shared `TaskList` component introduced in PR #808, ensuring consistency across different task views (all tasks, today's tasks, and group-specific tasks).