### PR TITLE
feat: add task deletion with open redirect protection

### DIFF
--- a/src/components/pages/task-page/delete-task-button/delete-task.api.ts
+++ b/src/components/pages/task-page/delete-task-button/delete-task.api.ts
@@ -1,0 +1,48 @@
+'use server'
+
+import { z } from 'zod'
+import { ResultObject } from '@/types/api'
+import { fetchData } from '@/utils/api/fetch-data'
+import { getBearerToken } from '@/utils/cookie/bearer-token'
+import { createErrorObject } from '@/utils/error/create-error-object'
+import { getRequestId } from '@/utils/request-id/get-request-id'
+import { validateData } from '@/utils/validation/validate-data'
+
+const dataSchema = z.null()
+
+type Data = z.infer<typeof dataSchema>
+
+type Params = {
+  taskId: string
+}
+
+export async function deleteTask({ taskId }: Params) {
+  const fetchDataResult = await fetchData(
+    `${process.env.API_ORIGIN}/api/v1/tasks/${taskId}`,
+    {
+      method: 'DELETE',
+      headers: {
+        Authorization: await getBearerToken(),
+      },
+    },
+  )
+
+  let resultObject: ResultObject<Data>
+
+  if (fetchDataResult instanceof Error) {
+    resultObject = createErrorObject(fetchDataResult)
+  } else {
+    const { headers, data } = fetchDataResult
+    const requestId = getRequestId(headers)
+
+    const validateDataResult = validateData({ requestId, dataSchema, data })
+
+    if (validateDataResult instanceof Error) {
+      resultObject = createErrorObject(validateDataResult)
+    } else {
+      resultObject = { status: 'success' }
+    }
+  }
+
+  return resultObject
+}

--- a/src/components/pages/task-page/delete-task-button/index.tsx
+++ b/src/components/pages/task-page/delete-task-button/index.tsx
@@ -1,0 +1,122 @@
+'use client'
+
+import { XMarkIcon } from '@heroicons/react/24/solid'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useEffect, useRef, useTransition } from 'react'
+import { useErrorSnackbar } from '@/app/_components/snackbars/snackbar/use-error-snackbar'
+import { Button } from '@/components/buttons/button'
+import { IconButton } from '@/components/buttons/icon-button'
+import { ModalContent } from '@/components/contents/modal-content'
+import { IconMessage } from '@/components/icon-message'
+import { Modal } from '@/components/modal'
+import { useModal } from '@/components/modal/use-modal'
+import { useRedirectLoginPath } from '@/utils/login-path/use-redirect-login-path'
+import { useQueryParams } from '@/utils/query-param/use-query-params'
+import { getSafeRedirectUrl } from '@/utils/url/get-safe-redirect-url'
+import { deleteTask } from './delete-task.api'
+
+type Props = {
+  id: string
+}
+
+export function DeleteTaskButton({ id }: Props) {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const fromUrlRef = useRef(searchParams.get('from_url'))
+  const { cleanupQueryParams } = useQueryParams({ searchParams })
+  const redirectLoginPath = useRedirectLoginPath({ searchParams })
+  const [isPending, startTransition] = useTransition()
+  const { openErrorSnackbar } = useErrorSnackbar()
+  const {
+    shouldMount,
+    isOpen,
+    openModal,
+    closeModal,
+    unmountModal,
+    handleAnimationEnd,
+    handleCancel,
+  } = useModal()
+
+  const handleOkClick = () => {
+    closeModal()
+    startTransition(async () => {
+      const result = await deleteTask({ taskId: id })
+      if (result.status === 'error') {
+        if (result.name === 'HttpError' && result.statusCode === 401) {
+          router.push(redirectLoginPath)
+        } else {
+          openErrorSnackbar(result)
+        }
+      } else {
+        const targetUrl = getSafeRedirectUrl(fromUrlRef.current, '/tasks')
+        router.replace(targetUrl)
+      }
+    })
+  }
+
+  const handleClose = (ev: React.SyntheticEvent<HTMLDialogElement, Event>) => {
+    ev.stopPropagation()
+    unmountModal()
+  }
+
+  useEffect(() => {
+    cleanupQueryParams(['from_url'])
+  }, [cleanupQueryParams])
+
+  return (
+    <>
+      <Button
+        type="button"
+        className="btn-danger"
+        status={isPending ? 'pending' : 'idle'}
+        onClick={openModal}
+      >
+        削除
+      </Button>
+      {shouldMount && (
+        <Modal
+          isOpen={isOpen}
+          onAnimationEnd={handleAnimationEnd}
+          onCancel={handleCancel}
+          onClose={handleClose}
+          onBackdropClick={closeModal}
+        >
+          <ModalContent
+            upperLeftIcon={
+              <IconButton
+                type="button"
+                aria-label="モーダルを閉じる"
+                onClick={closeModal}
+              >
+                <XMarkIcon className="size-6" />
+              </IconButton>
+            }
+          >
+            <IconMessage severity="warning" title="確認">
+              <p className="mb-5 sm:text-center">
+                本当にこのタスクを削除しますか？
+              </p>
+              <div className="mx-2.5 flex items-center justify-center gap-5">
+                <Button
+                  type="button"
+                  className="btn-danger"
+                  status={isPending ? 'disabled' : 'idle'}
+                  onClick={handleOkClick}
+                >
+                  削除
+                </Button>
+                <Button
+                  type="button"
+                  className="btn-ghost"
+                  onClick={closeModal}
+                >
+                  キャンセル
+                </Button>
+              </div>
+            </IconMessage>
+          </ModalContent>
+        </Modal>
+      )}
+    </>
+  )
+}

--- a/src/components/pages/task-page/index.tsx
+++ b/src/components/pages/task-page/index.tsx
@@ -1,4 +1,7 @@
 import { Suspense } from 'react'
+import { HorizontalRule } from '@/components/horizontal-rule'
+import { DetailItemContentLayout } from '@/components/layouts/detail-item-content-layout'
+import { DeleteTaskButton } from './delete-task-button'
 import {
   EditableTaskEndsAt,
   LoadingEditableTaskEndsAt,
@@ -54,6 +57,10 @@ export function TaskPage({ id }: Props) {
       <Suspense fallback={<LoadingEditableTaskNote />}>
         <EditableTaskNote id={id} />
       </Suspense>
+      <HorizontalRule />
+      <DetailItemContentLayout>
+        <DeleteTaskButton id={id} />
+      </DetailItemContentLayout>
     </div>
   )
 }

--- a/src/components/task-list/task-cards/task-card/index.tsx
+++ b/src/components/task-list/task-cards/task-card/index.tsx
@@ -3,6 +3,8 @@
 import { ClockIcon } from '@heroicons/react/24/outline'
 import { CalendarDateRangeIcon } from '@heroicons/react/24/solid'
 import Link from 'next/link'
+import { usePathname, useSearchParams } from 'next/navigation'
+import { generateFromUrlParam } from '@/utils/login-path/generate-from-url-param'
 
 type Props = {
   id: number
@@ -42,6 +44,9 @@ export function TaskCard({
   status,
   children,
 }: Props) {
+  const pathname = usePathname()
+  const params = useSearchParams()
+  const fromUrl = generateFromUrlParam(pathname, params.toString())
   const isOverdue = endsAt ? new Date(endsAt) < new Date() : false
 
   return (
@@ -95,7 +100,7 @@ export function TaskCard({
         </div>
         {children}
         <Link
-          href={`/tasks/detail/${id}`}
+          href={`/tasks/detail/${id}?${fromUrl}`}
           className="absolute top-0 left-0 h-full w-full rounded-md"
           aria-label={`${name}の詳細画面を表示`}
         />

--- a/src/utils/url/get-post-login-url.ts
+++ b/src/utils/url/get-post-login-url.ts
@@ -1,14 +1,5 @@
-const origin = process.env.NEXT_PUBLIC_FRONTEND_ORIGIN
+import { getSafeRedirectUrl } from './get-safe-redirect-url'
 
 export function getPostLoginUrl(fromUrl: string | null) {
-  let targetUrl = `${origin}/tasks`
-
-  if (fromUrl && URL.canParse(fromUrl)) {
-    const fromOrigin = new URL(fromUrl).origin
-    if (fromOrigin === origin) {
-      targetUrl = fromUrl
-    }
-  }
-
-  return targetUrl
+  return getSafeRedirectUrl(fromUrl, '/tasks')
 }

--- a/src/utils/url/get-safe-redirect-url.ts
+++ b/src/utils/url/get-safe-redirect-url.ts
@@ -1,0 +1,15 @@
+const origin = process.env.NEXT_PUBLIC_FRONTEND_ORIGIN
+
+export function getSafeRedirectUrl(
+  fromUrl: string | null,
+  defaultUrl: string,
+): string {
+  if (fromUrl && URL.canParse(fromUrl)) {
+    const fromOrigin = new URL(fromUrl).origin
+    if (fromOrigin === origin) {
+      return fromUrl
+    }
+  }
+
+  return defaultUrl
+}


### PR DESCRIPTION
### Summary

Add task deletion functionality to the task detail page with a confirmation modal. This implementation includes open redirect protection to ensure secure redirect handling after deletion.

### Changes

- Add `DeleteTaskButton` component with confirmation modal UI
- Add `deleteTask` server action for DELETE `/api/v1/tasks/:id` endpoint
- Create `getSafeRedirectUrl` utility function for open redirect protection
- Refactor `getPostLoginUrl` to use the new `getSafeRedirectUrl` utility
- Add `from_url` parameter to task card links for return navigation after viewing task details

### Testing

- Verified ESLint passes without errors
- Verified TypeScript type checking passes without errors
- Verified all Lefthook pre-commit checks pass (prettier, markuplint, knip, eslint)
- Manually verified task deletion functionality works correctly in the browser

![screen-recording-129](https://github.com/user-attachments/assets/f5352d3c-a1c9-433c-87e7-7266e4d7b3ec)
![screen-recording-130](https://github.com/user-attachments/assets/4c29e240-2556-4a08-aaee-5b1501199f0b)

### Related Issues

N/A

### Notes

The `getSafeRedirectUrl` utility validates that the redirect URL's origin matches the application's origin (`NEXT_PUBLIC_FRONTEND_ORIGIN`) to prevent open redirect vulnerabilities. If the URL is invalid or from a different origin, it falls back to the provided default URL.