### PR TITLE
fix: display tilde in TaskCard date when either start or end exists

### DIFF
--- a/src/components/task-list/task-cards/task-card/index.tsx
+++ b/src/components/task-list/task-cards/task-card/index.tsx
@@ -78,7 +78,7 @@ export function TaskCard({
             >
               <CalendarDateRangeIcon className="size-4" />
               {startsAt && <span>{formatDateTime(startsAt)}</span>}
-              {startsAt && endsAt && <span>~</span>}
+              {(startsAt || endsAt) && <span>~</span>}
               {endsAt && <span>{formatDateTime(endsAt)}</span>}
             </div>
           )}


### PR DESCRIPTION
### Summary

Fix the tilde separator display logic in TaskCard date range to show when either start date or end date exists.

### Changes

Modified the tilde display condition in TaskCard component from `startsAt && endsAt` to `(startsAt || endsAt)`. This ensures the tilde separator is displayed whenever at least one date (either start or end) is present, making the date range representation clearer.

**Display patterns after this change:**
- Start date only: "1月11日 23:22 ~"
- End date only: "~ 1月13日 19:52"
- Both dates: "1月13日 11:52 ~ 1月13日 19:52"
- No dates: Date section hidden

**File changed:**
- `src/components/task-list/task-cards/task-card/index.tsx` (line 80)

### Testing

**Automated checks:**
- ✅ ESLint passed
- ✅ TypeScript type checking passed
- ✅ Markuplint passed
- ✅ Knip (dead code detection) passed
- ✅ Prettier formatting verified

All pre-commit hooks passed successfully.

**Manual verification:**
- ✅ Verified tilde displays correctly when only start date exists
- ✅ Verified tilde displays correctly when only end date exists
- ✅ Verified tilde displays correctly when both dates exist
- ✅ Confirmed display matches intended behavior in all scenarios

<img width="754" height="524" alt="screen-shot-823" src="https://github.com/user-attachments/assets/0562c85b-4cf9-4a4b-8f88-5503d8950f68" />
<img width="738" height="508" alt="screen-shot-824" src="https://github.com/user-attachments/assets/2dd59f8a-e940-4fe8-9e2e-e04e6f91511e" />
<img width="742" height="506" alt="screen-shot-825" src="https://github.com/user-attachments/assets/8cddeec7-19f1-4313-b0fe-5b7c849ca2a0" />

### Related Issues

N/A

### Notes

No additional information or considerations at this time.