### PR TITLE
fix: ensure TaskCardsContainer maintains full height regardless of content

### DIFF
--- a/src/components/task-list/task-cards-container/index.tsx
+++ b/src/components/task-list/task-cards-container/index.tsx
@@ -97,32 +97,34 @@ export function TaskCardsContainer({
       <div className="flex h-12 shrink-0 items-center justify-between border-b border-gray-300"></div>
       <div
         ref={scrollContainerRef}
-        className="overflow-y-auto overscroll-y-none"
+        className="flex-1 overflow-y-auto overscroll-y-none"
         onWheel={handleWheel}
         onTouchStart={handleTouchStart}
         onTouchMove={handleTouchMove}
       >
-        {hasPrevPage && (
-          <ScrollTriggerPrevLink
-            currentPage={currentPage}
-            pageItems={pageItems}
-            linkRef={prevPageHook.linkRef}
-            pullProgress={prevPageHook.pullProgress}
-            shouldTransition={prevPageHook.shouldTransition}
-            onClick={handlePageTurnLinkClick}
-          />
-        )}
-        {children}
-        {hasNextPage && (
-          <ScrollTriggerNextLink
-            currentPage={currentPage}
-            pageItems={pageItems}
-            linkRef={nextPageHook.linkRef}
-            pullProgress={nextPageHook.pullProgress}
-            shouldTransition={nextPageHook.shouldTransition}
-            onClick={handlePageTurnLinkClick}
-          />
-        )}
+        <div className="min-h-[calc(100%+2.75rem)]">
+          {hasPrevPage && (
+            <ScrollTriggerPrevLink
+              currentPage={currentPage}
+              pageItems={pageItems}
+              linkRef={prevPageHook.linkRef}
+              pullProgress={prevPageHook.pullProgress}
+              shouldTransition={prevPageHook.shouldTransition}
+              onClick={handlePageTurnLinkClick}
+            />
+          )}
+          {children}
+          {hasNextPage && (
+            <ScrollTriggerNextLink
+              currentPage={currentPage}
+              pageItems={pageItems}
+              linkRef={nextPageHook.linkRef}
+              pullProgress={nextPageHook.pullProgress}
+              shouldTransition={nextPageHook.shouldTransition}
+              onClick={handlePageTurnLinkClick}
+            />
+          )}
+        </div>
       </div>
       <div className="relative flex h-12 shrink-0 items-center justify-center border-t border-gray-300">
         <Link


### PR DESCRIPTION
### Summary

Fix TaskCardsContainer to maintain full height regardless of the number of task cards.

### Changes

- Add `flex-1` to the scroll container to occupy all remaining space of the parent element
- Wrap content in a `min-h-[calc(100%+2.75rem)]` div to create a scrollable area and ensure scroll trigger links remain accessible

### Testing

- Verified that the container maintains full height when there are few task cards
- Verified that scroll trigger links work correctly even with few task cards
- Verified that scroll behavior with many task cards is unaffected

- Before
  <img width="798" height="1596" alt="screen-shot-826" src="https://github.com/user-attachments/assets/e7fb0b81-91df-4001-b838-92eea671bfc6" />

- After
  <img width="782" height="1436" alt="screen-shot-827" src="https://github.com/user-attachments/assets/f078f8b3-ab67-4ec5-9577-948d121f214b" />


### Related Issues (Optional)

N/A

### Notes (Optional)

No additional information or considerations at this time.