### PR TITLE
feat: add not found page for task detail

### DIFF
--- a/src/app/(main)/@modals/(.)tasks/detail/[id]/not-found.tsx
+++ b/src/app/(main)/@modals/(.)tasks/detail/[id]/not-found.tsx
@@ -1,0 +1,10 @@
+import { NotFoundContent } from '@/components/contents/not-found-content'
+import { IconMessage } from '@/components/icon-message'
+
+export default function NotFound() {
+  return (
+    <IconMessage severity="error" title="Not Found">
+      <NotFoundContent message="タスクが見つかりませんでした。" />
+    </IconMessage>
+  )
+}

--- a/src/app/(main)/tasks/detail/[id]/not-found.tsx
+++ b/src/app/(main)/tasks/detail/[id]/not-found.tsx
@@ -1,0 +1,12 @@
+import { NotFoundContent } from '@/components/contents/not-found-content'
+import { IconMessage } from '@/components/icon-message'
+
+export default function NotFound() {
+  return (
+    <div className="mt-40">
+      <IconMessage severity="error" title="Not Found">
+        <NotFoundContent message="タスクが見つかりませんでした。" />
+      </IconMessage>
+    </div>
+  )
+}


### PR DESCRIPTION
### Summary

Implement a dedicated 404 error page for the task detail route to provide clear user feedback when accessing non-existent tasks.

### Changes

- Add `not-found.tsx` to `src/app/(main)/tasks/detail/[id]/` directory
- Implement NotFound component using existing IconMessage and NotFoundContent components
- Follow the same error presentation pattern as the task group not-found page

### Testing

The implementation leverages existing error handling:
- `getTask()` utility (in `src/utils/api/get-task.ts`) already calls `notFound()` on 404 responses
- Next.js automatically renders the `not-found.tsx` when `notFound()` is invoked
- Manual verification: accessing `/tasks/detail/[invalid-id]` displays the error page correctly

<img width="2730" height="1804" alt="screen-shot-828" src="https://github.com/user-attachments/assets/98b8d8e8-8006-409c-bbe9-5337dae1f4b2" />
<img width="2726" height="1802" alt="screen-shot-829" src="https://github.com/user-attachments/assets/5df70450-fc56-482f-90ba-5de208db0287" />

### Related Issues

N/A

### Notes

No additional information or considerations at this time.