### PR TITLE
fix: hide PageSelector in TaskCardsContainer when only one page exists

### DIFF
--- a/src/components/task-list/task-cards-container/index.tsx
+++ b/src/components/task-list/task-cards-container/index.tsx
@@ -138,11 +138,13 @@ export function TaskCardsContainer({
         >
           <PlusIcon className="size-5 stroke-2" />
         </Link>
-        <PageSelector
-          currentPage={currentPage}
-          totalPages={totalPages}
-          onClick={handlePageSelectLinkClick}
-        />
+        {totalPages > 1 && (
+          <PageSelector
+            currentPage={currentPage}
+            totalPages={totalPages}
+            onClick={handlePageSelectLinkClick}
+          />
+        )}
         <CalendarButton />
       </div>
     </div>


### PR DESCRIPTION
### Summary

Hide the PageSelector component in TaskCardsContainer when only a single page exists to maintain a clean UI when pagination is unnecessary.

### Changes

- Added conditional rendering to PageSelector component in TaskCardsContainer
- PageSelector now displays only when `totalPages > 1`
- Maintains existing functionality for multi-page scenarios

### Testing

- Verified TypeScript type checking passes
- Verified ESLint checks pass
- Tested conditional rendering logic for both single-page and multi-page scenarios

- Before
  <img width="786" height="1592" alt="screen-shot-830" src="https://github.com/user-attachments/assets/e8e1f899-d461-46c5-a3cf-36ce30866de2" />

- After
  <img width="782" height="1582" alt="screen-shot-831" src="https://github.com/user-attachments/assets/3544681c-3dfd-4eeb-b43f-a85b82dddd48" />

### Related Issues (Optional)

N/A

### Notes (Optional)

No additional information or considerations at this time.