### PR TITLE
feat: improve TaskCard date display with conditional time hiding

### DIFF
--- a/src/components/task-list/task-cards/task-card/date-utils.ts
+++ b/src/components/task-list/task-cards/task-card/date-utils.ts
@@ -1,0 +1,33 @@
+export function isSameDay(startDate: Date, endDate: Date): boolean {
+  return (
+    startDate.getFullYear() === endDate.getFullYear() &&
+    startDate.getMonth() === endDate.getMonth() &&
+    startDate.getDate() === endDate.getDate()
+  )
+}
+
+export function isDefaultStartTime(startDate: Date): boolean {
+  return startDate.getHours() === 0 && startDate.getMinutes() === 0
+}
+
+export function isDefaultEndTime(endDate: Date): boolean {
+  return endDate.getHours() === 23 && endDate.getMinutes() === 59
+}
+
+export function checkShouldShowSingleDate(
+  startsAt?: string,
+  endsAt?: string,
+): boolean {
+  if (!startsAt || !endsAt) {
+    return false
+  }
+
+  const startDate = new Date(startsAt)
+  const endDate = new Date(endsAt)
+
+  return (
+    isSameDay(startDate, endDate) &&
+    isDefaultStartTime(startDate) &&
+    isDefaultEndTime(endDate)
+  )
+}

--- a/src/components/task-list/task-cards/task-card/format-utils.ts
+++ b/src/components/task-list/task-cards/task-card/format-utils.ts
@@ -1,0 +1,110 @@
+function formatDateOnly(date: Date) {
+  return date.toLocaleString('ja-JP', {
+    month: 'short',
+    day: 'numeric',
+  })
+}
+
+function formatDateWithTime(date: Date) {
+  return date.toLocaleString('ja-JP', {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+  })
+}
+
+type HasBothDefaultTimesParams = {
+  startHours: number
+  startMinutes: number
+  endHours: number
+  endMinutes: number
+}
+
+function hasBothDefaultTimes({
+  startHours,
+  startMinutes,
+  endHours,
+  endMinutes,
+}: HasBothDefaultTimesParams) {
+  return (
+    startHours === 0 &&
+    startMinutes === 0 &&
+    endHours === 23 &&
+    endMinutes === 59
+  )
+}
+
+export function formatStartDateTime(
+  startDateString: string,
+  endDateString?: string,
+) {
+  const startDate = new Date(startDateString)
+  const hours = startDate.getHours()
+  const minutes = startDate.getMinutes()
+
+  if (endDateString !== undefined) {
+    const endDate = new Date(endDateString)
+    const endHours = endDate.getHours()
+    const endMinutes = endDate.getMinutes()
+
+    if (
+      hasBothDefaultTimes({
+        startHours: hours,
+        startMinutes: minutes,
+        endHours,
+        endMinutes,
+      })
+    ) {
+      return formatDateOnly(startDate)
+    }
+  } else {
+    const isDefaultTime = hours === 0 && minutes === 0
+
+    if (isDefaultTime) {
+      return formatDateOnly(startDate)
+    }
+  }
+
+  return formatDateWithTime(startDate)
+}
+
+export function formatEndDateTime(
+  endDateString: string,
+  startDateString?: string,
+) {
+  const endDate = new Date(endDateString)
+  const hours = endDate.getHours()
+  const minutes = endDate.getMinutes()
+
+  if (startDateString !== undefined) {
+    const startDate = new Date(startDateString)
+    const startHours = startDate.getHours()
+    const startMinutes = startDate.getMinutes()
+
+    if (
+      hasBothDefaultTimes({
+        startHours,
+        startMinutes,
+        endHours: hours,
+        endMinutes: minutes,
+      })
+    ) {
+      return formatDateOnly(endDate)
+    }
+  } else {
+    const isDefaultTime = hours === 23 && minutes === 59
+
+    if (isDefaultTime) {
+      return formatDateOnly(endDate)
+    }
+  }
+
+  return formatDateWithTime(endDate)
+}
+
+export function formatMinutesToHoursAndMinutes(minutes: number): string {
+  const hours = Math.floor(minutes / 60)
+  const remainingMinutes = minutes % 60
+  return `${hours}時間${remainingMinutes}分`
+}

--- a/src/components/task-list/task-cards/task-card/index.tsx
+++ b/src/components/task-list/task-cards/task-card/index.tsx
@@ -5,6 +5,12 @@ import { CalendarDateRangeIcon } from '@heroicons/react/24/solid'
 import Link from 'next/link'
 import { usePathname, useSearchParams } from 'next/navigation'
 import { generateFromUrlParam } from '@/utils/login-path/generate-from-url-param'
+import { checkShouldShowSingleDate } from './date-utils'
+import {
+  formatStartDateTime,
+  formatEndDateTime,
+  formatMinutesToHoursAndMinutes,
+} from './format-utils'
 
 type Props = {
   id: number
@@ -16,21 +22,6 @@ type Props = {
   note?: string
   status: 'not_started' | 'in_progress' | 'completed'
   children?: React.ReactNode
-}
-
-function formatDateTime(dateString: string): string {
-  return new Date(dateString).toLocaleString('ja-JP', {
-    month: 'short',
-    day: 'numeric',
-    hour: 'numeric',
-    minute: 'numeric',
-  })
-}
-
-function formatMinutesToHoursAndMinutes(minutes: number): string {
-  const hours = Math.floor(minutes / 60)
-  const remainingMinutes = minutes % 60
-  return `${hours}時間${remainingMinutes}分`
 }
 
 export function TaskCard({
@@ -48,6 +39,8 @@ export function TaskCard({
   const params = useSearchParams()
   const fromUrl = generateFromUrlParam(pathname, params.toString())
   const isOverdue = endsAt ? new Date(endsAt) < new Date() : false
+
+  const shouldShowSingleDate = checkShouldShowSingleDate(startsAt, endsAt)
 
   return (
     <div className="relative transform rounded-md border border-gray-300 bg-white p-6 drop-shadow-sm transition-all duration-200 hover:scale-103 hover:drop-shadow-lg">
@@ -77,9 +70,17 @@ export function TaskCard({
               className={`flex flex-wrap items-center gap-1 text-xs ${isOverdue ? 'text-red-700' : 'text-gray-600'}`}
             >
               <CalendarDateRangeIcon className="size-4" />
-              {startsAt && <span>{formatDateTime(startsAt)}</span>}
-              {(startsAt || endsAt) && <span>~</span>}
-              {endsAt && <span>{formatDateTime(endsAt)}</span>}
+              {shouldShowSingleDate && startsAt && endsAt ? (
+                <span>{formatEndDateTime(endsAt, startsAt)}</span>
+              ) : (
+                <>
+                  {startsAt && (
+                    <span>{formatStartDateTime(startsAt, endsAt)}</span>
+                  )}
+                  {(startsAt || endsAt) && <span>~</span>}
+                  {endsAt && <span>{formatEndDateTime(endsAt, startsAt)}</span>}
+                </>
+              )}
             </div>
           )}
 


### PR DESCRIPTION
### Summary

Improve TaskCard date display by conditionally hiding time information based on default values (00:00 for start time, 23:59 for end time), making the date display cleaner and more intuitive.

### Changes

- Enhanced date display logic in TaskCard component:
  - Show single date without tilde when same day with both default times
  - Hide start time when 00:00 (if only start date exists)
  - Hide end time when 23:59 (if only end date exists)
  - Hide both times only when both exist and both have default values
- Added `date-utils.ts` with date validation utilities (`isSameDay`, `isDefaultStartTime`, `isDefaultEndTime`, `checkShouldShowSingleDate`)
- Added `format-utils.ts` with formatting utilities (`formatStartDateTime`, `formatEndDateTime`, `formatMinutesToHoursAndMinutes`)
- Refactored TaskCard to use new utility modules for better code organization

### Testing

- Verified TypeScript type checking passes
- Verified ESLint checks pass
- Manually tested various date/time combinations:
  - Same day with default times (00:00 and 23:59) displays single date
    <img width="740" height="488" alt="screen-shot-832" src="https://github.com/user-attachments/assets/0abab359-3f45-49ac-aa36-9df53b827ae0" />
  - Single dates with default times hide time portion
    <img width="730" height="490" alt="screen-shot-834" src="https://github.com/user-attachments/assets/4a76ef35-60d1-472e-905a-4df2b8301745" />
    <img width="748" height="412" alt="screen-shot-835" src="https://github.com/user-attachments/assets/e3ffee7f-fd76-4c40-a762-1ef0e317da8f" />
  - Both dates with both default times hide both time portions
 	 <img width="728" height="392" alt="screen-shot-836" src="https://github.com/user-attachments/assets/2416f8af-fd61-4581-acf6-29bcb02f6198" />
  - Mixed scenarios display time correctly
    <img width="732" height="502" alt="screen-shot-833" src="https://github.com/user-attachments/assets/8338d673-7074-4fbc-8d77-d64239750e2a" />

### Related Issues

N/A

### Notes

No additional information or considerations at this time.