### PR TITLE
feat: replace task card checkbox with interactive status box

### DIFF
--- a/src/components/pages/task-page/editable-task-status/task-status-editor/index.tsx
+++ b/src/components/pages/task-page/editable-task-status/task-status-editor/index.tsx
@@ -6,10 +6,10 @@ import { z } from 'zod'
 import { useErrorSnackbar } from '@/app/_components/snackbars/snackbar/use-error-snackbar'
 import { taskSchema } from '@/schemas/response/task'
 import { ErrorObject } from '@/types/error'
+import { changeTaskStatus } from '@/utils/api/change-task-status'
 import { HttpError } from '@/utils/error/custom/http-error'
 import { useRedirectLoginPath } from '@/utils/login-path/use-redirect-login-path'
 import { isValidValue } from '@/utils/type-guard/is-valid-value'
-import { changeTaskStatus } from './change-task-status.api'
 
 type Props = {
   taskId: string

--- a/src/components/task-list/task-cards/task-card/date-utils.ts
+++ b/src/components/task-list/task-cards/task-card/date-utils.ts
@@ -1,4 +1,4 @@
-export function isSameDay(startDate: Date, endDate: Date): boolean {
+function isSameDay(startDate: Date, endDate: Date): boolean {
   return (
     startDate.getFullYear() === endDate.getFullYear() &&
     startDate.getMonth() === endDate.getMonth() &&
@@ -6,11 +6,11 @@ export function isSameDay(startDate: Date, endDate: Date): boolean {
   )
 }
 
-export function isDefaultStartTime(startDate: Date): boolean {
+function isDefaultStartTime(startDate: Date): boolean {
   return startDate.getHours() === 0 && startDate.getMinutes() === 0
 }
 
-export function isDefaultEndTime(endDate: Date): boolean {
+function isDefaultEndTime(endDate: Date): boolean {
   return endDate.getHours() === 23 && endDate.getMinutes() === 59
 }
 

--- a/src/components/task-list/task-cards/task-card/index.tsx
+++ b/src/components/task-list/task-cards/task-card/index.tsx
@@ -11,6 +11,7 @@ import {
   formatEndDateTime,
   formatMinutesToHoursAndMinutes,
 } from './format-utils'
+import { TaskStatusBox } from './task-status-box'
 
 type Props = {
   id: number
@@ -39,6 +40,7 @@ export function TaskCard({
   const params = useSearchParams()
   const fromUrl = generateFromUrlParam(pathname, params.toString())
   const isOverdue = endsAt ? new Date(endsAt) < new Date() : false
+  const taskId = id.toString()
 
   const shouldShowSingleDate = checkShouldShowSingleDate(startsAt, endsAt)
 
@@ -47,13 +49,9 @@ export function TaskCard({
       <div className={`${status === 'completed' ? 'opacity-80' : ''}`}>
         <div className="flex flex-col gap-2">
           <div className="flex items-center gap-2">
-            <input
-              type="checkbox"
-              checked={status === 'completed'}
-              className="pointer-events-none size-5 rounded-md"
-              aria-label={`${name}の完了状態`}
-              onChange={() => {}}
-            />
+            <div className="z-10 flex items-center">
+              <TaskStatusBox taskId={taskId} taskName={name} status={status} />
+            </div>
             <h2
               className={`truncate text-lg font-bold ${status === 'completed' ? 'text-gray-600 line-through' : ''}`}
             >
@@ -101,7 +99,7 @@ export function TaskCard({
         </div>
         {children}
         <Link
-          href={`/tasks/detail/${id}?${fromUrl}`}
+          href={`/tasks/detail/${taskId}?${fromUrl}`}
           className="absolute top-0 left-0 h-full w-full rounded-md"
           aria-label={`${name}の詳細画面を表示`}
         />

--- a/src/components/task-list/task-cards/task-card/task-status-box/index.tsx
+++ b/src/components/task-list/task-cards/task-card/task-status-box/index.tsx
@@ -1,0 +1,80 @@
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useTransition } from 'react'
+import { useErrorSnackbar } from '@/app/_components/snackbars/snackbar/use-error-snackbar'
+import { ErrorObject } from '@/types/error'
+import { changeTaskStatus } from '@/utils/api/change-task-status'
+import { HttpError } from '@/utils/error/custom/http-error'
+import { useRedirectLoginPath } from '@/utils/login-path/use-redirect-login-path'
+import { StatusSquare } from './status-square'
+
+type Status = 'not_started' | 'in_progress' | 'completed'
+
+type Props = {
+  taskId: string
+  taskName: string
+  status: Status
+}
+
+const statusOrder: Status[] = ['not_started', 'in_progress', 'completed']
+
+const statusLabels: Record<Status, string> = {
+  not_started: '未着手',
+  in_progress: '対応中',
+  completed: '完了',
+}
+
+function getNextStatus(currentStatus: Status): Status {
+  const currentIndex = statusOrder.indexOf(currentStatus)
+  const nextIndex = (currentIndex + 1) % statusOrder.length
+  return statusOrder[nextIndex]
+}
+
+export function TaskStatusBox({ taskId, taskName, status }: Props) {
+  const [isPending, startTransition] = useTransition()
+  const { openErrorSnackbar } = useErrorSnackbar()
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const redirectLoginPath = useRedirectLoginPath({ searchParams })
+  const nextStatus = getNextStatus(status)
+  const currentLabel = statusLabels[status]
+  const nextLabel = statusLabels[nextStatus]
+
+  const handleHttpError = (err: ErrorObject<HttpError>) => {
+    if (err.statusCode === 401) {
+      router.push(redirectLoginPath)
+    } else {
+      openErrorSnackbar(err)
+    }
+  }
+
+  const handleClick = () => {
+    startTransition(async () => {
+      const result = await changeTaskStatus({
+        taskId: taskId,
+        bodyData: { status: nextStatus },
+      })
+
+      if (result.status === 'error') {
+        if (result.name === 'HttpError') {
+          handleHttpError(result)
+        } else {
+          openErrorSnackbar(result)
+        }
+      }
+    })
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={isPending}
+      aria-label={`${taskName}のステータスを${currentLabel}から${nextLabel}に変更`}
+      className={
+        isPending ? 'animate-pulse cursor-not-allowed' : 'hover:brightness-75'
+      }
+    >
+      <StatusSquare status={status} />
+    </button>
+  )
+}

--- a/src/components/task-list/task-cards/task-card/task-status-box/status-square/index.tsx
+++ b/src/components/task-list/task-cards/task-card/task-status-box/status-square/index.tsx
@@ -1,0 +1,28 @@
+import { CheckIcon } from '@heroicons/react/24/outline'
+
+type Props = {
+  status: 'not_started' | 'in_progress' | 'completed'
+}
+
+function getColorClasses(status: Props['status']) {
+  switch (status) {
+    case 'completed':
+      return 'bg-green-600'
+    case 'in_progress':
+      return 'bg-orange-500'
+    case 'not_started':
+      return 'border-2 border-gray-400 bg-gray-100'
+  }
+}
+
+export function StatusSquare({ status }: Props) {
+  return (
+    <div
+      className={`flex size-5 items-center justify-center rounded-sm ${getColorClasses(status)}`}
+    >
+      {status === 'completed' && (
+        <CheckIcon className="size-4 stroke-white stroke-3" />
+      )}
+    </div>
+  )
+}

--- a/src/utils/api/change-task-status.ts
+++ b/src/utils/api/change-task-status.ts
@@ -55,7 +55,8 @@ export async function changeTaskStatus({ taskId, bodyData }: Params) {
         status: 'success',
         ...camelcaseKeys(validateDataResult, { deep: true }),
       }
-      revalidatePath(`/tasks/detail/${resultObject.task.id}`)
+
+      revalidatePath('/tasks', 'layout')
     }
   }
 


### PR DESCRIPTION
### Summary

Replace the read-only checkbox in TaskCard with TaskStatusBox, an
interactive component that cycles through task statuses
(not_started → in_progress → completed) via Server Action.

### Changes

- Replace read-only checkbox with TaskStatusBox component in TaskCard
- Add StatusSquare subcomponent to render visual status indicator
- Move change-task-status.ts to utils/api for reuse across task list
  and detail pages, updating revalidatePath to cover both
- Remove unused exports from date-utils.ts

### Testing

Verified task status cycling (not_started → in_progress → completed) by clicking the status box in the task list view.
![screen-recording-142](https://github.com/user-attachments/assets/0d967e5a-795d-4c55-99ab-3d1cb9e3439f)

### Related Issues (Optional)

Related Issues: N/A

### Notes (Optional)

Notes: No additional information or considerations at this time.