### PR TITLE
chore: add git-spice devcontainer feature

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,24 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    },
+    "ghcr.io/P-manBrown/devcontainer-features/common-utils:2": {
+      "version": "2.0.8",
+      "resolved": "ghcr.io/p-manbrown/devcontainer-features/common-utils@sha256:62c2b1275270d9e1708bae3c05d1a27151fc67563bd3735135a4656425854923",
+      "integrity": "sha256:62c2b1275270d9e1708bae3c05d1a27151fc67563bd3735135a4656425854923"
+    },
+    "ghcr.io/P-manBrown/devcontainer-features/git-from-src-fast:1": {
+      "version": "1.0.1",
+      "resolved": "ghcr.io/p-manbrown/devcontainer-features/git-from-src-fast@sha256:5f883b37e858b51cf3abb81b991b1160d3b863616f299a91dfd33e4d13e6e8cf",
+      "integrity": "sha256:5f883b37e858b51cf3abb81b991b1160d3b863616f299a91dfd33e4d13e6e8cf"
+    },
+    "ghcr.io/P-manBrown/devcontainer-features/git-spice:1": {
+      "version": "1.0.0",
+      "resolved": "ghcr.io/p-manbrown/devcontainer-features/git-spice@sha256:dbdfd638f1eec31bcd427674186b4eb860062f2dd9e54d120ce8928b9d75cf78",
+      "integrity": "sha256:dbdfd638f1eec31bcd427674186b4eb860062f2dd9e54d120ce8928b9d75cf78"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,6 +12,7 @@
       "upgradePackages": false
     },
     "ghcr.io/P-manBrown/devcontainer-features/git-from-src-fast:1": {},
+    "ghcr.io/P-manBrown/devcontainer-features/git-spice:1": {},
     "ghcr.io/devcontainers/features/github-cli:1": {}
   },
   "customizations": {


### PR DESCRIPTION
### Summary

Add the git-spice CLI to the dev container so stacked-branch workflows work inside the container.

### Changes

- Add the `ghcr.io/P-manBrown/devcontainer-features/git-spice:1` feature to `devcontainer.json`, installing the git-spice CLI (`gs`) inside the dev container
- Add `devcontainer-lock.json`, generated as a side effect of adding the feature, pinning the resolved versions of all installed features (including the existing github-cli, common-utils, and git-from-src-fast features) for reproducible builds

### Testing

Rebuilt the dev container and confirmed the `gs` command is available inside the container.

### Related Issues

N/A

### Notes

No additional information or considerations at this time.