### PR TITLE
chore: add codex devcontainer feature

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -10,6 +10,11 @@
       "resolved": "ghcr.io/p-manbrown/devcontainer-features/claude-code@sha256:4c967a1c532f9ab494d899683eea695a2c33815ed8f33d7a8a9c7cf20c01d8f8",
       "integrity": "sha256:4c967a1c532f9ab494d899683eea695a2c33815ed8f33d7a8a9c7cf20c01d8f8"
     },
+    "ghcr.io/P-manBrown/devcontainer-features/codex:1": {
+      "version": "1.0.3",
+      "resolved": "ghcr.io/p-manbrown/devcontainer-features/codex@sha256:ac527329dcdea8054e86362debf51c396d5f1e1569c42009b017b2927b56a8cd",
+      "integrity": "sha256:ac527329dcdea8054e86362debf51c396d5f1e1569c42009b017b2927b56a8cd"
+    },
     "ghcr.io/P-manBrown/devcontainer-features/common-utils:2": {
       "version": "2.0.8",
       "resolved": "ghcr.io/p-manbrown/devcontainer-features/common-utils@sha256:62c2b1275270d9e1708bae3c05d1a27151fc67563bd3735135a4656425854923",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,8 @@
     "ghcr.io/P-manBrown/devcontainer-features/git-from-src-fast:1": {},
     "ghcr.io/P-manBrown/devcontainer-features/git-spice:1": {},
     "ghcr.io/devcontainers/features/github-cli:1": {},
-    "ghcr.io/P-manBrown/devcontainer-features/claude-code:1": {}
+    "ghcr.io/P-manBrown/devcontainer-features/claude-code:1": {},
+    "ghcr.io/P-manBrown/devcontainer-features/codex:1": {}
   },
   "customizations": {
     "vscode": {


### PR DESCRIPTION
### Summary

Add the codex feature to the dev container so the Codex CLI is available inside the container.

### Changes

- Add the `ghcr.io/P-manBrown/devcontainer-features/codex:1` feature to `devcontainer.json`, installing the Codex CLI inside the dev container
- Update `devcontainer-lock.json`, regenerated as a side effect of adding the feature, with the resolved version of the codex feature for reproducible builds

### Testing

Rebuilt the dev container and confirmed the Codex CLI is available inside the container.

### Related Issues

N/A

### Notes

No additional information or considerations at this time.