### PR TITLE
chore: add MCP and plugin config

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,30 @@
+{
+  "enabledPlugins": {
+    "genshijin@genshijin": true,
+    "codex@openai-codex": true,
+    "context-mode@context-mode": true
+  },
+  "extraKnownMarketplaces": {
+    "genshijin": {
+      "source": {
+        "source": "github",
+        "repo": "InterfaceX-co-jp/genshijin"
+      },
+      "autoUpdate": true
+    },
+    "openai-codex": {
+      "source": {
+        "source": "github",
+        "repo": "openai/codex-plugin-cc"
+      },
+      "autoUpdate": true
+    },
+    "context-mode": {
+      "source": {
+        "source": "github",
+        "repo": "mksglu/context-mode"
+      },
+      "autoUpdate": true
+    }
+  }
+}

--- a/.devcontainer/compose.devcontainer.yml
+++ b/.devcontainer/compose.devcontainer.yml
@@ -2,7 +2,6 @@ services:
   frontend:
     volumes:
       - shell-log:/home/${FRONTEND_USER_NAME}/shell_log
-      - codebase-memory-mcp-cache:/home/${FRONTEND_USER_NAME}/.cache/codebase-memory-mcp
     command: bash -c 'while sleep 1000; do :; done'
     environment:
       - COREPACK_ENABLE_STRICT=0
@@ -10,4 +9,3 @@ services:
       - ./.devcontainer/environment/gh-token.env
 volumes:
   shell-log:
-  codebase-memory-mcp-cache:

--- a/.devcontainer/compose.devcontainer.yml
+++ b/.devcontainer/compose.devcontainer.yml
@@ -2,6 +2,7 @@ services:
   frontend:
     volumes:
       - shell-log:/home/${FRONTEND_USER_NAME}/shell_log
+      - codebase-memory-mcp-cache:/home/${FRONTEND_USER_NAME}/.cache/codebase-memory-mcp
     command: bash -c 'while sleep 1000; do :; done'
     environment:
       - COREPACK_ENABLE_STRICT=0
@@ -9,3 +10,4 @@ services:
       - ./.devcontainer/environment/gh-token.env
 volumes:
   shell-log:
+  codebase-memory-mcp-cache:

--- a/.devcontainer/compose.devcontainer.yml
+++ b/.devcontainer/compose.devcontainer.yml
@@ -3,8 +3,6 @@ services:
     volumes:
       - shell-log:/home/${FRONTEND_USER_NAME}/shell_log
     command: bash -c 'while sleep 1000; do :; done'
-    environment:
-      - COREPACK_ENABLE_STRICT=0
     env_file:
       - ./.devcontainer/environment/gh-token.env
 volumes:

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,5 +1,10 @@
 {
   "features": {
+    "ghcr.io/devcontainers-extra/features/bun:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers-extra/features/bun@sha256:0624284ecaead9dd4c6654616a7f939cfa4ebcbc60593700a74e35b1767befa5",
+      "integrity": "sha256:0624284ecaead9dd4c6654616a7f939cfa4ebcbc60593700a74e35b1767befa5"
+    },
     "ghcr.io/devcontainers/features/github-cli:1": {
       "version": "1.1.0",
       "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
@@ -10,10 +15,15 @@
       "resolved": "ghcr.io/p-manbrown/devcontainer-features/claude-code@sha256:4c967a1c532f9ab494d899683eea695a2c33815ed8f33d7a8a9c7cf20c01d8f8",
       "integrity": "sha256:4c967a1c532f9ab494d899683eea695a2c33815ed8f33d7a8a9c7cf20c01d8f8"
     },
-    "ghcr.io/P-manBrown/devcontainer-features/codex:1": {
-      "version": "1.0.3",
-      "resolved": "ghcr.io/p-manbrown/devcontainer-features/codex@sha256:ac527329dcdea8054e86362debf51c396d5f1e1569c42009b017b2927b56a8cd",
-      "integrity": "sha256:ac527329dcdea8054e86362debf51c396d5f1e1569c42009b017b2927b56a8cd"
+    "ghcr.io/P-manBrown/devcontainer-features/codebase-memory-mcp:1": {
+      "version": "1.0.0",
+      "resolved": "ghcr.io/p-manbrown/devcontainer-features/codebase-memory-mcp@sha256:9333228d8e57b46e01714eec843c325aca4e424a5c0d82757e90e59d62e0ffc7",
+      "integrity": "sha256:9333228d8e57b46e01714eec843c325aca4e424a5c0d82757e90e59d62e0ffc7"
+    },
+    "ghcr.io/P-manBrown/devcontainer-features/codex:2": {
+      "version": "2.0.0",
+      "resolved": "ghcr.io/p-manbrown/devcontainer-features/codex@sha256:b3a5b7a6bae74f8cd896545a6225a298a5b10b04ec2e19ba049a70930379f935",
+      "integrity": "sha256:b3a5b7a6bae74f8cd896545a6225a298a5b10b04ec2e19ba049a70930379f935"
     },
     "ghcr.io/P-manBrown/devcontainer-features/common-utils:2": {
       "version": "2.0.8",
@@ -29,6 +39,11 @@
       "version": "1.0.0",
       "resolved": "ghcr.io/p-manbrown/devcontainer-features/git-spice@sha256:dbdfd638f1eec31bcd427674186b4eb860062f2dd9e54d120ce8928b9d75cf78",
       "integrity": "sha256:dbdfd638f1eec31bcd427674186b4eb860062f2dd9e54d120ce8928b9d75cf78"
+    },
+    "ghcr.io/P-manBrown/devcontainer-features/rtk:1": {
+      "version": "1.0.1",
+      "resolved": "ghcr.io/p-manbrown/devcontainer-features/rtk@sha256:2f2fc1f7c041070cfca2ddadd8fafab616b1481cf6f5a57302a02c40fb6758d0",
+      "integrity": "sha256:2f2fc1f7c041070cfca2ddadd8fafab616b1481cf6f5a57302a02c40fb6758d0"
     }
   }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,7 @@
     "ghcr.io/P-manBrown/devcontainer-features/git-spice:1": {},
     "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/P-manBrown/devcontainer-features/claude-code:1": {},
-    "ghcr.io/P-manBrown/devcontainer-features/codex:1": {},
+    "ghcr.io/P-manBrown/devcontainer-features/codex:2": {},
     "ghcr.io/P-manBrown/devcontainer-features/codebase-memory-mcp:1": {
       "autoIndex": true
     },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,6 +16,9 @@
     "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/P-manBrown/devcontainer-features/claude-code:1": {},
     "ghcr.io/P-manBrown/devcontainer-features/codex:1": {},
+    "ghcr.io/P-manBrown/devcontainer-features/codebase-memory-mcp:1": {
+      "autoIndex": true
+    },
     "ghcr.io/devcontainers-extra/features/bun:1": {}
   },
   "customizations": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,7 +19,10 @@
     "ghcr.io/P-manBrown/devcontainer-features/codebase-memory-mcp:1": {
       "autoIndex": true
     },
-    "ghcr.io/devcontainers-extra/features/bun:1": {}
+    "ghcr.io/devcontainers-extra/features/bun:1": {},
+    "ghcr.io/P-manBrown/devcontainer-features/rtk:1": {
+      "claudeCodeHook": true
+    }
   },
   "customizations": {
     "vscode": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,8 @@
     "ghcr.io/P-manBrown/devcontainer-features/git-spice:1": {},
     "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/P-manBrown/devcontainer-features/claude-code:1": {},
-    "ghcr.io/P-manBrown/devcontainer-features/codex:1": {}
+    "ghcr.io/P-manBrown/devcontainer-features/codex:1": {},
+    "ghcr.io/devcontainers-extra/features/bun:1": {}
   },
   "customizations": {
     "vscode": {

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ next-env.d.ts
 /public/sw.js.map
 /public/workbox-*.js
 /public/workbox-*.js.map
+
+# Claude Code
+/.claude/settings.local.json


### PR DESCRIPTION
### Summary

Add the codebase-memory-mcp, bun, and rtk devcontainer features, and add Claude Code plugin config.

### Changes

- Add the `ghcr.io/P-manBrown/devcontainer-features/codebase-memory-mcp:1` feature to `devcontainer.json` (`autoIndex: true`). It runs after claude-code and codex, installs the binary at build time with checksum verification, and configures detected coding agents plus auto-index at container start
- Add the `ghcr.io/devcontainers-extra/features/bun:1` feature to `devcontainer.json` so the context-mode plugin can auto-detect Bun for its faster JS/TS sandboxed execution path
- Add the `ghcr.io/P-manBrown/devcontainer-features/rtk:1` feature to `devcontainer.json` (`claudeCodeHook: true`), enabling the Claude Code PreToolUse hook to reduce bash output token usage
- Add `.claude/settings.json`, configuring the genshijin, codex-plugin-cc, and context-mode plugins (including marketplace definitions) at the project scope, along with a `.gitignore` entry for `/.claude/settings.local.json`
- Remove `COREPACK_ENABLE_STRICT=0` from `compose.devcontainer.yml`, since Claude Code no longer requires Zed's ACP to work and the Corepack strict mode override added in 8181c522 is no longer needed
- Update `devcontainer-lock.json`, regenerated as a side effect of the feature additions, pinning the newly resolved versions

### Testing

Rebuilt the dev container and confirmed the added features install correctly and the Claude Code plugin configuration is applied.

### Related Issues

N/A

### Notes

No additional information or considerations at this time.