### PR TITLE
chore: use official devcontainer features for common-utils and git

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -5,6 +5,16 @@
       "resolved": "ghcr.io/devcontainers-extra/features/bun@sha256:0624284ecaead9dd4c6654616a7f939cfa4ebcbc60593700a74e35b1767befa5",
       "integrity": "sha256:0624284ecaead9dd4c6654616a7f939cfa4ebcbc60593700a74e35b1767befa5"
     },
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "version": "2.5.9",
+      "resolved": "ghcr.io/devcontainers/features/common-utils@sha256:cb0c4d3c276f157eed17935747e364178d75fee17f55c4e129966f64633deb3a",
+      "integrity": "sha256:cb0c4d3c276f157eed17935747e364178d75fee17f55c4e129966f64633deb3a"
+    },
+    "ghcr.io/devcontainers/features/git:1": {
+      "version": "1.3.8",
+      "resolved": "ghcr.io/devcontainers/features/git@sha256:fd75977de13a9979000e0e78baf949adb0ca71d2398995fa22e0a36d7e7e7fe2",
+      "integrity": "sha256:fd75977de13a9979000e0e78baf949adb0ca71d2398995fa22e0a36d7e7e7fe2"
+    },
     "ghcr.io/devcontainers/features/github-cli:1": {
       "version": "1.1.0",
       "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
@@ -24,16 +34,6 @@
       "version": "2.0.0",
       "resolved": "ghcr.io/p-manbrown/devcontainer-features/codex@sha256:b3a5b7a6bae74f8cd896545a6225a298a5b10b04ec2e19ba049a70930379f935",
       "integrity": "sha256:b3a5b7a6bae74f8cd896545a6225a298a5b10b04ec2e19ba049a70930379f935"
-    },
-    "ghcr.io/P-manBrown/devcontainer-features/common-utils:2": {
-      "version": "2.0.8",
-      "resolved": "ghcr.io/p-manbrown/devcontainer-features/common-utils@sha256:62c2b1275270d9e1708bae3c05d1a27151fc67563bd3735135a4656425854923",
-      "integrity": "sha256:62c2b1275270d9e1708bae3c05d1a27151fc67563bd3735135a4656425854923"
-    },
-    "ghcr.io/P-manBrown/devcontainer-features/git-from-src-fast:1": {
-      "version": "1.0.1",
-      "resolved": "ghcr.io/p-manbrown/devcontainer-features/git-from-src-fast@sha256:5f883b37e858b51cf3abb81b991b1160d3b863616f299a91dfd33e4d13e6e8cf",
-      "integrity": "sha256:5f883b37e858b51cf3abb81b991b1160d3b863616f299a91dfd33e4d13e6e8cf"
     },
     "ghcr.io/P-manBrown/devcontainer-features/git-spice:1": {
       "version": "1.0.0",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,11 +7,11 @@
   "remoteUser": "node",
   "postCreateCommand": "bash ./.devcontainer/postCreateCommand.sh",
   "features": {
-    "ghcr.io/P-manBrown/devcontainer-features/common-utils:2": {
+    "ghcr.io/devcontainers/features/common-utils:2": {
       "configureZshAsDefaultShell": true,
       "upgradePackages": false
     },
-    "ghcr.io/P-manBrown/devcontainer-features/git-from-src-fast:1": {},
+    "ghcr.io/devcontainers/features/git:1": {},
     "ghcr.io/P-manBrown/devcontainer-features/git-spice:1": {},
     "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/P-manBrown/devcontainer-features/claude-code:1": {},


### PR DESCRIPTION
### Summary

Migrate the `common-utils` and `git` devcontainer features from custom P-manBrown forks to the official `devcontainers/features` equivalents, reducing the maintenance burden of the custom forks.

### Changes

- `.devcontainer/devcontainer.json`: `common-utils` feature source changed from `ghcr.io/P-manBrown/devcontainer-features/common-utils:2` to `ghcr.io/devcontainers/features/common-utils:2` (options unchanged)
- `.devcontainer/devcontainer.json`: `git` feature source changed from `ghcr.io/P-manBrown/devcontainer-features/git-from-src-fast:1` to `ghcr.io/devcontainers/features/git:1`

### Testing

Rebuilt the devcontainer and confirmed the common-utils and git features install correctly.

### Related Issues (Optional)

N/A

### Notes (Optional)

No additional information or considerations at this time.