### PR TITLE
chore: install gh-stack extension in dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,9 @@
     },
     "ghcr.io/devcontainers/features/git:1": {},
     "ghcr.io/P-manBrown/devcontainer-features/git-spice:1": {},
-    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "extensions": "github/gh-stack"
+    },
     "ghcr.io/P-manBrown/devcontainer-features/claude-code:1": {},
     "ghcr.io/P-manBrown/devcontainer-features/codex:2": {},
     "ghcr.io/P-manBrown/devcontainer-features/codebase-memory-mcp:1": {

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -30,6 +30,7 @@ git config --local core.editor 'zed --wait'
 
 echo 'Setting up GitHub CLI...'
 gh config set editor 'zed --wait'
+gh skill install github/gh-stack
 
 echo 'Setting up Lefthook...'
 yarn lefthook install


### PR DESCRIPTION
### Summary

Add the gh-stack GitHub CLI extension and its companion AI agent skill to the dev container, enabling stacked branch/PR management via `gh stack`.

### Changes

- `github-cli` devcontainer feature's `extensions` option now includes `github/gh-stack`, making the `gh stack` subcommand available in the container
- `postCreateCommand.sh` runs `gh skill install github/gh-stack` so AI coding agents in the container understand the `gh stack` workflow

### Testing

- Verified `gh stack --help` runs successfully inside the dev container
- Verified `gh skill list` shows the `gh-stack` skill after installation

### Related Issues (Optional)

N/A

### Notes (Optional)

`gh-stack` is being introduced alongside the existing git-spice workflow. Once all branches currently stacked with git-spice have been merged into `main`, the project will switch its stacked-PR workflow from git-spice to `gh-stack`.