### PR TITLE
chore: expose codebase-memory-mcp ui on port 9749

### DIFF
--- a/.devcontainer/compose.devcontainer.yml
+++ b/.devcontainer/compose.devcontainer.yml
@@ -2,6 +2,8 @@ services:
   frontend:
     volumes:
       - shell-log:/home/${FRONTEND_USER_NAME}/shell_log
+    ports:
+      - '9749:9749'
     command: bash -c 'while sleep 1000; do :; done'
     env_file:
       - ./.devcontainer/environment/gh-token.env

--- a/.devcontainer/compose.devcontainer.yml
+++ b/.devcontainer/compose.devcontainer.yml
@@ -3,7 +3,7 @@ services:
     volumes:
       - shell-log:/home/${FRONTEND_USER_NAME}/shell_log
     ports:
-      - '9749:9749'
+      - '127.0.0.1:9749:9749'
     command: bash -c 'while sleep 1000; do :; done'
     env_file:
       - ./.devcontainer/environment/gh-token.env

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,7 +19,8 @@
     "ghcr.io/P-manBrown/devcontainer-features/claude-code:1": {},
     "ghcr.io/P-manBrown/devcontainer-features/codex:2": {},
     "ghcr.io/P-manBrown/devcontainer-features/codebase-memory-mcp:1": {
-      "autoIndex": true
+      "autoIndex": true,
+      "ui": true
     },
     "ghcr.io/devcontainers-extra/features/bun:1": {},
     "ghcr.io/P-manBrown/devcontainer-features/rtk:1": {


### PR DESCRIPTION
### Summary

Enable the codebase-memory-mcp web ui so its graph visualization can be viewed from the host, while keeping it inaccessible from the LAN.

### Changes

- Enable the `ui` option for the codebase-memory-mcp devcontainer feature
- Publish port 9749 bound to `127.0.0.1` only, so the ui is reachable from the Docker host but not exposed to the LAN

### Testing

- Rebuilt the Dev Container after the change
- Confirmed `curl http://localhost:9749` returns `200` from the host
- Confirmed the ui is unreachable from the host's LAN IP (e.g. `curl http://192.168.x.x:9749` fails to connect), verifying the port is not exposed beyond the Docker host

### Related Issues (Optional)

N/A

### Notes (Optional)

No additional information or considerations at this time.